### PR TITLE
Scroll the last edited evidence to the top of the screen after reload

### DIFF
--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -27,6 +27,7 @@ export default (props: {
   onQueryUpdate: (q: string) => void,
   operationSlug: string,
   query: string,
+  scrollToUuid?: string,
 }) => {
   const rootRef = React.useRef<HTMLDivElement | null>(null)
   const lightboxRef = React.useRef<HTMLDivElement | null>(null)
@@ -85,6 +86,7 @@ export default (props: {
       {props.evidence.map((evi, idx) => (
         <TimelineRow
           {...props}
+          focusUuid={props.scrollToUuid}
           active={activeChildIndex === idx}
           evidence={evi}
           key={evi.uuid}
@@ -117,9 +119,18 @@ const TimelineRow = (props: {
   onQueryUpdate: (q: string) => void,
   operationSlug: string,
   query: string,
+  focusUuid?: string,
   onPreviewClick: () => void,
   onClick: () => void,
 }) => {
+  const self = React.useRef<null | HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    if (self.current != null && props.evidence.uuid == props.focusUuid) {
+      self.current.scrollIntoView()
+    }
+  }, [self, props.focusUuid])
+
   const onTagClick = (t: Tag) => {
     props.onQueryUpdate(addTagToQuery(props.query, t.name))
   }
@@ -131,7 +142,7 @@ const TimelineRow = (props: {
   const permalink = `${window.location.origin}/operations/${props.operationSlug}/evidence/${props.evidence.uuid}`
 
   return (
-    <div className={cx('timeline-row', { active: props.active })} onClick={props.onClick}>
+    <div ref={self} className={cx('timeline-row', { active: props.active })} onClick={props.onClick}>
       <div className={cx('left')}>
         <EvidencePreview
           fitToContainer

--- a/frontend/src/pages/operation_show/finding_show/index.tsx
+++ b/frontend/src/pages/operation_show/finding_show/index.tsx
@@ -20,21 +20,30 @@ export default (props: RouteComponentProps<{slug: string, uuid: string}>) => {
     operationSlug: slug,
     findingUuid: uuid,
   }), [slug, uuid]))
+  const [lastEditedUuid, setLastEditedUuid] = React.useState("")
+
+  const reloadToTop = () => {
+    setLastEditedUuid("")
+    wiredFinding.reload()
+  }
 
   const addRemoveEvidenceModal = useModal<{finding: Finding, initialEvidence: Array<Evidence>}>(modalProps => (
-    <ChangeEvidenceOfFindingModal {...modalProps} onChanged={wiredFinding.reload} operationSlug={slug} />
+    <ChangeEvidenceOfFindingModal {...modalProps} onChanged={reloadToTop} operationSlug={slug} />
   ))
   const editFindingModal = useModal<{finding: Finding}>(modalProps => (
-    <EditFindingModal {...modalProps} onEdited={wiredFinding.reload} operationSlug={slug} />
+    <EditFindingModal {...modalProps} onEdited={reloadToTop} operationSlug={slug} />
   ))
   const deleteFindingModal = useModal<{finding: Finding}>(modalProps => (
     <DeleteFindingModal {...modalProps} onDeleted={() => props.history.push(`/operations/${slug}/findings`)} operationSlug={slug} />
   ))
   const editEvidenceModal = useModal<{evidence: Evidence}>(modalProps => (
-    <EditEvidenceModal {...modalProps} onEdited={wiredFinding.reload} operationSlug={slug} />
+    <EditEvidenceModal {...modalProps} onEdited={ ()=>{
+      setLastEditedUuid(modalProps.evidence.uuid)
+      wiredFinding.reload()
+    }} operationSlug={slug} />
   ))
   const removeEvidenceFromFindingModal = useModal<{evidence: Evidence, finding: Finding}>(modalProps => (
-    <RemoveEvidenceFromFindingModal {...modalProps} onRemoved={wiredFinding.reload} operationSlug={slug} />
+    <RemoveEvidenceFromFindingModal {...modalProps} onRemoved={reloadToTop} operationSlug={slug} />
   ))
 
   return <>
@@ -53,6 +62,7 @@ export default (props: RouteComponentProps<{slug: string, uuid: string}>) => {
         </div>
         <div className={cx('timeline')}>
           <Timeline
+            scrollToUuid={lastEditedUuid}
             evidence={evidence}
             actions={{
               'Remove From Finding': evidence => removeEvidenceFromFindingModal.show({evidence, finding}),


### PR DESCRIPTION
This PR keeps track of the the uuid of the last edited evidence, so that on reload we can scroll back to that evidence. 

Addresses Issue #23 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
