### PR TITLE
Add error wrapping and error tracing

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -175,6 +175,26 @@ The project contains various source code directories, effectively acting as a co
 └── schema.sql                         # The accumulated deployment schema -- useful when starting from scratch
 ```
 
+### Errors and logging
+
+The error model used within this application adopts the following principles:
+
+* Use structured logging, to help finding/reporting errors
+  * Logs are of the form: `timestamp=<ISO8601> key=value`
+  * Common labels and meanings
+    * `error` the error text for the underlying error. Wrapped errors are separated by ` : `
+    * `msg` a general note on what operation is happening, or what unusual thing just happened
+    * `ctx` the unique identifier that corresponds all (eligible) messages together by a particular request
+    * All other values generally represent application state
+* Use wrapped errors to help pinpoint the path an error took
+* Export a (formatted) stacktrace for unexpected panics
+* All error messages have two messages: a public one, exposing no real information to the user, and a private one, that gets logged
+  * Errors containing the following text:
+    * "Unwilling to" suggests that a request did not pass a permissions check.
+    * "Unable to" suggests that some critical data was missing
+    * "Cannot" suggests that we tried, and failed, to do the requested operation
+    * messages that do not match the above generally have more specific information to identify them
+
 ### Visual Studio Code Notes
 
 If you're using Visual Studio Code, you may want to make these changes:

--- a/backend/contentstore/memstore.go
+++ b/backend/contentstore/memstore.go
@@ -73,6 +73,8 @@ func (d *MemStore) Delete(key string) error {
 	if _, ok := d.content[key]; !ok { // artificial behavior to match other stores
 		return backend.WrapError("Unable to delete from MemStore", fmt.Errorf("No such key"))
 	}
+	d.mutex.Lock()
 	delete(d.content, key)
+	d.mutex.Unlock()
 	return nil
 }

--- a/backend/contentstore/s3store.go
+++ b/backend/contentstore/s3store.go
@@ -42,7 +42,7 @@ func (s *S3Store) Upload(data io.Reader) (string, error) {
 		Bucket: aws.String(s.bucketName),
 		Key:    aws.String(key),
 	})
-	
+
 	if err != nil {
 		return key, backend.WrapError("Upload to s3 failed", err)
 	}
@@ -68,7 +68,7 @@ func (s *S3Store) Delete(key string) error {
 		Bucket: aws.String(s.bucketName),
 		Key:    aws.String(key),
 	})
-		
+
 	if err != nil {
 		return backend.WrapError("Delete from s3 failed", err)
 	}

--- a/backend/contentstore/s3store.go
+++ b/backend/contentstore/s3store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/google/uuid"
+	"github.com/theparanoids/ashirt-server/backend"
 )
 
 // S3Store is the backing structure needed to interact with an Amazon S3 storage service
@@ -23,7 +24,7 @@ type S3Store struct {
 func NewS3Store(bucketName string, region string) (*S3Store, error) {
 	sess, err := session.NewSession()
 	if err != nil {
-		return nil, err
+		return nil, backend.WrapError("Unable to establish an s3 session", err)
 	}
 	return &S3Store{
 		bucketName: bucketName,
@@ -41,8 +42,12 @@ func (s *S3Store) Upload(data io.Reader) (string, error) {
 		Bucket: aws.String(s.bucketName),
 		Key:    aws.String(key),
 	})
+	
+	if err != nil {
+		return key, backend.WrapError("Upload to s3 failed", err)
+	}
 
-	return key, err
+	return key, nil
 }
 
 // Read retrieves the indicated file from Amazon S3
@@ -52,7 +57,7 @@ func (s *S3Store) Read(key string) (io.Reader, error) {
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil, err
+		return nil, backend.WrapError("Unable to read from s3", err)
 	}
 	return res.Body, nil
 }
@@ -63,5 +68,10 @@ func (s *S3Store) Delete(key string) error {
 		Bucket: aws.String(s.bucketName),
 		Key:    aws.String(key),
 	})
-	return err
+		
+	if err != nil {
+		return backend.WrapError("Delete from s3 failed", err)
+	}
+
+	return nil
 }

--- a/backend/database/helpers.go
+++ b/backend/database/helpers.go
@@ -103,7 +103,10 @@ func (c *Connection) BatchInsert(tableName string, count int, mapFn func(int) ma
 func (c *Connection) Update(ub squirrel.UpdateBuilder) error {
 	ub = ub.Set("updated_at", time.Now())
 	_, err := c.execSquirrel(ub)
-	return err
+	if err != nil {
+		return fmt.Errorf("Unable to execute db update : %w", err)
+	}
+	return nil
 }
 
 // Delete removes records indicated by the given DeleteBuilder

--- a/backend/dtos/gentypes/generate_typescript_types.go
+++ b/backend/dtos/gentypes/generate_typescript_types.go
@@ -34,7 +34,7 @@ func main() {
 	gen(dtos.TagDifference{})
 
 	// Since this file only contains typescript types, webpack doesn't pick up the
-	// changes unless there is some actual executable javascript reverenced from
+	// changes unless there is some actual executable javascript referenced from
 	// the app itself. By exporting an empty function and calling it in the app
 	// https://github.com/TypeStrong/ts-loader/issues/808
 	fmt.Println("export function cacheBust() {}")

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -151,3 +151,8 @@ func IsErrorAccountDisabled(err error) bool {
 func DisabledUserError() error {
 	return errors.New("This account has been disabled. Please contact an adminstrator if you think this is an error.")
 }
+
+// PanicedError represents any error the occurs
+func PanicedError() error {
+	return HTTPErr(http.StatusInternalServerError, "An unknown error occurred", errors.New("Pancied during processing"))
+}

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -23,6 +23,28 @@ func (e *HTTPError) Error() string {
 	return e.WrappedError.Error()
 }
 
+// Rewrap allows re-wrapping the wrapped error to include more information. The new error will
+// consist of the newly provided message, followed by a colon, followed by the original error.
+// e.g. err := HttpError(500, "private err", "public err"); err.Rewrap("outer"); // produces a wrapped error of "outer : private err"
+func (e *HTTPError) Rewrap(msg string) {
+	e.WrappedError = fmt.Errorf("%v : %w", msg, e.WrappedError)
+}
+
+// WrapError provides a mechanism to wrap any error in a consistent manner.
+// If the error is an HTTPError (as defined in this package), then HTTPError.Rewrap will be called
+// If the error is a regular error (i.e. non HTTPError), then a similar wrapping will occur, but the error will remain a non-HTTP error
+// If the error is neither an HTTPError or regular error (i.e. the error is nil), then a new error will be generate with the provided message
+func WrapError(msg string, err error) error {
+	switch err := err.(type) {
+	case *HTTPError:
+		err.Rewrap(msg)
+		return err
+	case error:
+		return fmt.Errorf("%v : %w", msg, err)
+	}
+	return fmt.Errorf(msg)
+}
+
 func HTTPErr(statusCode int, reason string, wrappedError error) error {
 	return &HTTPError{
 		HTTPStatus:   statusCode,
@@ -114,6 +136,8 @@ func AccountDisabled() error {
 	return HTTPErr(http.StatusForbidden, err.Error(), err)
 }
 
+// IsErrorAccountDisabled checks if the provided error is the same as an "Account Disabled" error.
+// See AccountDisabled() in this package.
 func IsErrorAccountDisabled(err error) bool {
 	switch err := err.(type) {
 	case *HTTPError:

--- a/backend/helpers/query_parser.go
+++ b/backend/helpers/query_parser.go
@@ -4,12 +4,12 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/theparanoids/ashirt-server/backend"
 )
 
@@ -177,7 +177,7 @@ func parseTime(str string, useEndOfDayIfTimeIsMissing bool) (time.Time, error) {
 	}
 
 	return time.Now(), backend.BadInputErr(
-		errors.Wrap(fmt.Errorf("RFC3339: %v ;; ISO8601: %v", rfc3339Err, iso8601Err), "Failed to parse time"),
+		fmt.Errorf("Failed to parse time. (RFC3339: %v) (ISO8601: %v)", rfc3339Err.Error(), iso8601Err.Error()),
 		fmt.Sprintf("Query ranges must be in ISO8601 or RFC3339 format. (Got '%s')", str),
 	)
 }

--- a/backend/server/remux/response_wrappers.go
+++ b/backend/server/remux/response_wrappers.go
@@ -17,13 +17,20 @@ import (
 // the output will instead be json, which conforms to the remainder of the project
 func MediaHandler(handler func(*http.Request) (io.Reader, error)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, err := handler(r)
-		if err != nil {
-			HandleError(w, r, err)
-			return
-		}
+		var data io.Reader
+		var err error
+		defer watcher(logging.ReqLogger(r.Context()), func(paniced bool) {
+			if paniced {
+				err = backend.PanicedError()
+			}
+			if err != nil {
+				HandleError(w, r, err)
+				return
+			}
 
-		io.Copy(w, data)
+			io.Copy(w, data)
+		})
+		data, err = handler(r)
 	})
 }
 
@@ -33,17 +40,24 @@ func MediaHandler(handler func(*http.Request) (io.Reader, error)) http.Handler {
 // is returned.
 func JSONHandler(handler func(*http.Request) (interface{}, error)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, err := handler(r)
-		if err != nil {
-			HandleError(w, r, err)
-			return
-		}
+		var data interface{}
+		var err error
+		defer watcher(logging.ReqLogger(r.Context()), func(paniced bool) {
+			if paniced {
+				err = backend.PanicedError()
+			}
+			if err != nil {
+				HandleError(w, r, err)
+				return
+			}
 
-		status := 200
-		if r.Method == "POST" {
-			status = 201
-		}
-		writeJSONResponse(w, status, data)
+			status := 200
+			if r.Method == "POST" {
+				status = 201
+			}
+			writeJSONResponse(w, status, data)
+		})
+		data, err = handler(r)
 	})
 }
 
@@ -67,9 +81,10 @@ func HandleError(w http.ResponseWriter, r *http.Request, err error) {
 		status = http.StatusInternalServerError
 		publicReason = "An unknown error occurred"
 		loggedReason = err
+		logging.Log(r.Context(), "msg", "handling non-HTTPError", "stacktrace", formatStackTrace(retrace(20)))
 	}
 
-	logging.Log(r.Context(), "msg", "Error handling request", "error", loggedReason.Error(), "url", r.URL)
+	logging.Log(r.Context(), "msg", "Error handling request", "error", loggedReason.Error(), "status", status, "url", r.URL)
 
 	writeJSONResponse(w, status, map[string]string{"error": publicReason})
 }

--- a/backend/server/remux/response_wrappers.go
+++ b/backend/server/remux/response_wrappers.go
@@ -55,21 +55,21 @@ func JSONHandler(handler func(*http.Request) (interface{}, error)) http.Handler 
 func HandleError(w http.ResponseWriter, r *http.Request, err error) {
 	var status int
 	var publicReason string
-	var loggedReason string
+	var loggedReason error
 
 	switch err := err.(type) {
 	case *backend.HTTPError:
 		status = err.HTTPStatus
 		publicReason = err.PublicReason
-		loggedReason = err.WrappedError.Error()
+		loggedReason = err.WrappedError
 
 	case error:
 		status = http.StatusInternalServerError
 		publicReason = "An unknown error occurred"
-		loggedReason = err.Error()
+		loggedReason = err
 	}
 
-	logging.Log(r.Context(), "error", loggedReason, "url", r.URL)
+	logging.Log(r.Context(), "msg", "Error handling request", "error", loggedReason.Error(), "url", r.URL)
 
 	writeJSONResponse(w, status, map[string]string{"error": publicReason})
 }

--- a/backend/server/remux/tracing.go
+++ b/backend/server/remux/tracing.go
@@ -1,0 +1,59 @@
+package remux
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/theparanoids/ashirt-server/backend/logging"
+)
+
+// StackTraceEntry is a small structure for holding relevent data pertaining to a single line
+// in a stacktrace.
+type StackTraceEntry struct {
+	File       string
+	LineNumber int
+}
+
+// watcher provides a mechanism to recover from panics. Start this prior to launching
+// questionable code. If a panic occurs, this will catch that panic, log the response,
+// and execute the provided cleanup code. a boolean provided to the cleanup code 
+// indicates if a panic occurred.
+func watcher(log logging.Logger, cleanup func(bool)) {
+	paniced := false
+	if r := recover(); r != nil {
+		paniced = true
+		strTrace := formatStackTrace(retrace(25))
+		log.Log("msg", "unexpected panic", "recoveredData", r, "stacktrace", strTrace)
+	}
+	cleanup(paniced)
+}
+
+// retrace follows the call stack backwards to determine where the program has been
+// This follows up to the specified number of steps, or when the callstack is unavailable
+func retrace(maxSteps int) []StackTraceEntry {
+	steps := make([]StackTraceEntry, 0, maxSteps)
+
+	for i := 0; i < maxSteps; i++ {
+		// 0 = self, 1 = caller, so start at 2 to go back in time
+		_, file, line, ok := runtime.Caller(2 + i)
+		if ok {
+			steps = append(steps, StackTraceEntry{File: file, LineNumber: line})
+		} else {
+			break
+		}
+	}
+	return steps
+}
+
+// formatStackTrace provides a mechanism for turning a list of StackTraceEntries into a single-line
+// structure
+func formatStackTrace(points []StackTraceEntry) string {
+	output := make([]string, len(points))
+	glue := " : "
+
+	for i, step := range points {
+		output[i] = fmt.Sprintf("[ %v ] @ line %v", step.File, step.LineNumber)
+	}
+	return strings.Join(output, glue)
+}

--- a/backend/server/remux/tracing.go
+++ b/backend/server/remux/tracing.go
@@ -17,7 +17,7 @@ type StackTraceEntry struct {
 
 // watcher provides a mechanism to recover from panics. Start this prior to launching
 // questionable code. If a panic occurs, this will catch that panic, log the response,
-// and execute the provided cleanup code. a boolean provided to the cleanup code 
+// and execute the provided cleanup code. a boolean provided to the cleanup code
 // indicates if a panic occurred.
 func watcher(log logging.Logger, cleanup func(bool)) {
 	paniced := false

--- a/backend/services/create_api_key.go
+++ b/backend/services/create_api_key.go
@@ -47,7 +47,7 @@ func CreateAPIKey(ctx context.Context, db *database.Connection, userSlug string)
 		"secret_key": secretKey,
 	})
 	if err != nil {
-		return nil, backend.WrapError("Unable to record api and secret keys",backend.DatabaseErr(err))
+		return nil, backend.WrapError("Unable to record api and secret keys", backend.DatabaseErr(err))
 	}
 
 	return &dtos.APIKey{

--- a/backend/services/create_api_key.go
+++ b/backend/services/create_api_key.go
@@ -23,22 +23,22 @@ func CreateAPIKey(ctx context.Context, db *database.Connection, userSlug string)
 	var err error
 
 	if userID, err = selfOrSlugToUserID(ctx, db, userSlug); err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Unable to create api key", backend.DatabaseErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyAPIKeys{UserID: userID}); err != nil {
-		return nil, backend.UnauthorizedWriteErr(err)
+		return nil, backend.WrapError("Unable to create api key", backend.UnauthorizedWriteErr(err))
 	}
 
 	accessKey := make([]byte, accessKeyLength)
 	if _, err := rand.Read(accessKey); err != nil {
-		return nil, err
+		return nil, backend.WrapError("Unable to generate api key", err)
 	}
 	accessKeyStr := base64.URLEncoding.EncodeToString(accessKey)
 
 	secretKey := make([]byte, secretKeyLength)
 	if _, err := rand.Read(secretKey); err != nil {
-		return nil, err
+		return nil, backend.WrapError("Unable to create secret key", err)
 	}
 
 	_, err = db.Insert("api_keys", map[string]interface{}{
@@ -47,7 +47,7 @@ func CreateAPIKey(ctx context.Context, db *database.Connection, userSlug string)
 		"secret_key": secretKey,
 	})
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Unable to record api and secret keys",backend.DatabaseErr(err))
 	}
 
 	return &dtos.APIKey{

--- a/backend/services/create_evidence.go
+++ b/backend/services/create_evidence.go
@@ -30,11 +30,11 @@ type CreateEvidenceInput struct {
 func CreateEvidence(ctx context.Context, db *database.Connection, contentStore contentstore.Store, i CreateEvidenceInput) (*dtos.Evidence, error) {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedWriteErr(err)
+		return nil, backend.WrapError("Unable to create evidence", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyEvidenceOfOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedWriteErr(err)
+		return nil, backend.WrapError("Unable to create evidence", backend.UnauthorizedWriteErr(err))
 	}
 
 	if i.OccurredAt.IsZero() {
@@ -66,7 +66,7 @@ func CreateEvidence(ctx context.Context, db *database.Connection, contentStore c
 			if httpErr, ok := err.(*backend.HTTPError); ok {
 				return nil, httpErr
 			}
-			return nil, backend.UploadErr(err)
+			return nil, backend.WrapError("Unable to upload evidence", backend.UploadErr(err))
 		}
 	}
 
@@ -92,7 +92,7 @@ func CreateEvidence(ctx context.Context, db *database.Connection, contentStore c
 	})
 
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Could not create evidence and tags", backend.DatabaseErr(err))
 	}
 
 	return &dtos.Evidence{

--- a/backend/services/create_finding.go
+++ b/backend/services/create_finding.go
@@ -24,11 +24,11 @@ type CreateFindingInput struct {
 func CreateFinding(ctx context.Context, db *database.Connection, i CreateFindingInput) (*dtos.Finding, error) {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedWriteErr(err)
+		return nil, backend.WrapError("Unable to create finding", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyFindingsOfOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedWriteErr(err)
+		return nil, backend.WrapError("Unable to create finding", backend.UnauthorizedWriteErr(err))
 	}
 
 	if i.Title == "" {
@@ -48,7 +48,7 @@ func CreateFinding(ctx context.Context, db *database.Connection, i CreateFinding
 		"description":  i.Description,
 	})
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Unable to insert finding", backend.DatabaseErr(err))
 	}
 
 	return &dtos.Finding{

--- a/backend/services/create_tag.go
+++ b/backend/services/create_tag.go
@@ -22,11 +22,11 @@ type CreateTagInput struct {
 func CreateTag(ctx context.Context, db *database.Connection, i CreateTagInput) (*dtos.Tag, error) {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to create tag", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyTagsOfOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedWriteErr(err)
+		return nil, backend.WrapError("Unable to create tag", backend.UnauthorizedWriteErr(err))
 	}
 
 	if i.Name == "" {
@@ -39,7 +39,7 @@ func CreateTag(ctx context.Context, db *database.Connection, i CreateTagInput) (
 		"operation_id": operation.ID,
 	})
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot add new tag", backend.DatabaseErr(err))
 	}
 	return &dtos.Tag{
 		ID:        tagID,

--- a/backend/services/delete_api_key.go
+++ b/backend/services/delete_api_key.go
@@ -24,11 +24,11 @@ func DeleteAPIKey(ctx context.Context, db *database.Connection, i DeleteAPIKeyIn
 	var err error
 
 	if userID, err = selfOrSlugToUserID(ctx, db, i.UserSlug); err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Unable to delete API Key", backend.DatabaseErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyAPIKeys{UserID: userID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to delete API Key", backend.UnauthorizedWriteErr(err))
 	}
 
 	var apiKeyID int64
@@ -41,9 +41,9 @@ func DeleteAPIKey(ctx context.Context, db *database.Connection, i DeleteAPIKeyIn
 	})
 	if err != nil {
 		if database.IsEmptyResultSetError(err) {
-			return backend.UnauthorizedWriteErr(err)
+			return backend.WrapError("API key does not exist", backend.UnauthorizedWriteErr(err))
 		}
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot delete API key", backend.DatabaseErr(err))
 	}
 
 	return nil

--- a/backend/services/delete_auth_scheme.go
+++ b/backend/services/delete_auth_scheme.go
@@ -28,16 +28,16 @@ func DeleteAuthScheme(ctx context.Context, db *database.Connection, i DeleteAuth
 	var err error
 
 	if userID, err = selfOrSlugToUserID(ctx, db, i.UserSlug); err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Unable to delete auth scheme", backend.DatabaseErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanDeleteAuthScheme{UserID: userID, SchemeCode: i.SchemeName}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to delete auth scheme", backend.UnauthorizedWriteErr(err))
 	}
 
 	err = db.Delete(sq.Delete("auth_scheme_data").Where(sq.Eq{"user_id": userID, "auth_scheme": i.SchemeName}))
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot delete auth scheme", backend.DatabaseErr(err))
 	}
 
 	return nil

--- a/backend/services/delete_auth_scheme_users.go
+++ b/backend/services/delete_auth_scheme_users.go
@@ -17,12 +17,12 @@ import (
 // DeleteAuthSchemeUsers removes/unlinks all users from a provided scheme
 func DeleteAuthSchemeUsers(ctx context.Context, db *database.Connection, schemeCode string) error {
 	if err := policy.Require(middleware.Policy(ctx), policy.CanDeleteAuthForAllUsers{SchemeCode: schemeCode}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to remove auth schemes for all users", backend.UnauthorizedWriteErr(err))
 	}
 
 	err := db.Delete(sq.Delete("auth_scheme_data").Where(sq.Eq{"auth_scheme": schemeCode}))
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot remove auth schemes for all users", backend.DatabaseErr(err))
 	}
 
 	return nil

--- a/backend/services/delete_operation.go
+++ b/backend/services/delete_operation.go
@@ -21,11 +21,11 @@ import (
 func DeleteOperation(ctx context.Context, db *database.Connection, contentStore contentstore.Store, slug string) error {
 	operation, err := lookupOperation(db, slug)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unable to delete operation", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policyRequireWithAdminBypass(ctx, policy.CanDeleteOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to delete operation", backend.UnauthorizedWriteErr(err))
 	}
 	log := logging.ReqLogger(ctx)
 
@@ -78,7 +78,7 @@ func DeleteOperation(ctx context.Context, db *database.Connection, contentStore 
 		if err != nil {
 			log.Log("task", "delete operation", "msg", "Failed to fully delete operation data",
 				"error", err.Error())
-			return backend.DatabaseErr(err)
+			return backend.WrapError("Cannot delete operation", backend.DatabaseErr(err))
 		}
 		return nil
 	})

--- a/backend/services/delete_query.go
+++ b/backend/services/delete_query.go
@@ -23,16 +23,16 @@ type DeleteQueryInput struct {
 func DeleteQuery(ctx context.Context, db *database.Connection, i DeleteQueryInput) error {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unable to delete query", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyQueriesOfOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to delete query", backend.UnauthorizedWriteErr(err))
 	}
 
 	err = db.Delete(sq.Delete("queries").Where(sq.Eq{"id": i.ID, "operation_id": operation.ID}))
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot delete query", backend.DatabaseErr(err))
 	}
 
 	return nil

--- a/backend/services/list_api_keys.go
+++ b/backend/services/list_api_keys.go
@@ -21,11 +21,11 @@ func ListAPIKeys(ctx context.Context, db *database.Connection, userSlug string) 
 	var err error
 
 	if userID, err = selfOrSlugToUserID(ctx, db, userSlug); err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Unable to list api keys", backend.DatabaseErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanListAPIKeys{UserID: userID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list api keys", backend.UnauthorizedReadErr(err))
 	}
 
 	var keys []models.APIKey
@@ -34,7 +34,7 @@ func ListAPIKeys(ctx context.Context, db *database.Connection, userSlug string) 
 		Where(sq.Eq{"user_id": userID}))
 
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list api keys", backend.DatabaseErr(err))
 	}
 
 	keysDTO := make([]*dtos.APIKey, len(keys))

--- a/backend/services/list_auths_details.go
+++ b/backend/services/list_auths_details.go
@@ -23,7 +23,7 @@ type detailedSchemeTable struct {
 
 func ListAuthDetails(ctx context.Context, db *database.Connection, supportedAuthSchemes *[]dtos.SupportedAuthScheme) ([]*dtos.DetailedAuthenticationInfo, error) {
 	if err := isAdmin(ctx); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list auth details", backend.UnauthorizedReadErr(err))
 	}
 
 	var detailedAuthData []detailedSchemeTable
@@ -41,7 +41,7 @@ func ListAuthDetails(ctx context.Context, db *database.Connection, supportedAuth
 			GroupBy("auth_scheme"))
 
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list auth details", backend.DatabaseErr(err))
 	}
 
 	return mergeSchemes(detailedAuthData, supportedAuthSchemes), nil

--- a/backend/services/list_evidence_for_finding.go
+++ b/backend/services/list_evidence_for_finding.go
@@ -24,11 +24,11 @@ type ListEvidenceForFindingInput struct {
 func ListEvidenceForFinding(ctx context.Context, db *database.Connection, i ListEvidenceForFindingInput) ([]dtos.Evidence, error) {
 	operation, finding, err := lookupOperationFinding(db, i.OperationSlug, i.FindingUUID)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to list evidence for finding", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanReadOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list evidence for finding", backend.UnauthorizedReadErr(err))
 	}
 
 	var evidenceForFinding []struct {
@@ -44,7 +44,7 @@ func ListEvidenceForFinding(ctx context.Context, db *database.Connection, i List
 		Where(sq.Eq{"finding_id": finding.ID}))
 
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Cannot list evidence for finding", backend.UnauthorizedReadErr(err))
 	}
 
 	evidenceIDs := make([]int64, len(evidenceForFinding))
@@ -54,7 +54,7 @@ func ListEvidenceForFinding(ctx context.Context, db *database.Connection, i List
 
 	tagsByEvidenceID, _, err := tagsForEvidenceByID(db, evidenceIDs)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Cannot get tags for evidnece", backend.UnauthorizedReadErr(err))
 	}
 
 	var evidenceDTOs = make([]dtos.Evidence, len(evidenceForFinding))

--- a/backend/services/list_evidence_for_operation.go
+++ b/backend/services/list_evidence_for_operation.go
@@ -27,11 +27,11 @@ type ListEvidenceForOperationInput struct {
 func ListEvidenceForOperation(ctx context.Context, db *database.Connection, i ListEvidenceForOperationInput) ([]*dtos.Evidence, error) {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to list evidence for an operation", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanReadOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list evidence for an operation", backend.UnauthorizedReadErr(err))
 	}
 
 	var evidence []struct {
@@ -50,7 +50,7 @@ func ListEvidenceForOperation(ctx context.Context, db *database.Connection, i Li
 
 	err = db.Select(&evidence, sb)
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list evidence for an operation", backend.DatabaseErr(err))
 	}
 
 	if len(evidence) == 0 {
@@ -64,7 +64,7 @@ func ListEvidenceForOperation(ctx context.Context, db *database.Connection, i Li
 
 	tagsByEvidenceID, _, err := tagsForEvidenceByID(db, evidenceIDs)
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot get tags for evidence", backend.DatabaseErr(err))
 	}
 
 	evidenceDTO := make([]*dtos.Evidence, len(evidence))

--- a/backend/services/list_operations.go
+++ b/backend/services/list_operations.go
@@ -31,7 +31,7 @@ func listAllOperations(db *database.Connection) ([]*dtos.Operation, error) {
 		GroupBy("operations.id").
 		OrderBy("operations.created_at DESC"))
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list all operations", backend.DatabaseErr(err))
 	}
 
 	operationsDTO := []*dtos.Operation{}

--- a/backend/services/list_queries_for_operation.go
+++ b/backend/services/list_queries_for_operation.go
@@ -20,11 +20,11 @@ import (
 func ListQueriesForOperation(ctx context.Context, db *database.Connection, operationSlug string) ([]*dtos.Query, error) {
 	operation, err := lookupOperation(db, operationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to list queries", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanReadOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list queries", backend.UnauthorizedReadErr(err))
 	}
 
 	var queries = make([]models.Query, 0)
@@ -34,7 +34,7 @@ func ListQueriesForOperation(ctx context.Context, db *database.Connection, opera
 		OrderBy("name ASC"))
 
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list queries", backend.DatabaseErr(err))
 	}
 
 	var queriesDTO = make([]*dtos.Query, len(queries))

--- a/backend/services/list_tags_for_operation.go
+++ b/backend/services/list_tags_for_operation.go
@@ -22,11 +22,11 @@ type ListTagsForOperationInput struct {
 func ListTagsForOperation(ctx context.Context, db *database.Connection, i ListTagsForOperationInput) ([]*dtos.TagWithUsage, error) {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to list tags for operation", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policyRequireWithAdminBypass(ctx, policy.CanReadOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list tags for operation", backend.UnauthorizedReadErr(err))
 	}
 
 	return listTagsForOperation(db, operation.ID)
@@ -48,7 +48,7 @@ func listTagsForOperation(db *database.Connection, operationID int64) ([]*dtos.T
 		GroupBy("tags.id").
 		OrderBy("tags.id ASC"))
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot get tags for operation", backend.DatabaseErr(err))
 	}
 
 	tagsDTO := make([]*dtos.TagWithUsage, len(tags))

--- a/backend/services/list_users.go
+++ b/backend/services/list_users.go
@@ -39,7 +39,7 @@ func ListUsers(ctx context.Context, db *database.Connection, i ListUsersInput) (
 	}
 	err := db.Select(&users, query)
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list users", backend.DatabaseErr(err))
 	}
 
 	usersDTO := []*dtos.User{}

--- a/backend/services/list_users_for_admin.go
+++ b/backend/services/list_users_for_admin.go
@@ -25,7 +25,7 @@ type ListUsersForAdminInput struct {
 // meant for admin review. For use in admin views only.
 func ListUsersForAdmin(ctx context.Context, db *database.Connection, i ListUsersForAdminInput) (*dtos.PaginationWrapper, error) {
 	if err := isAdmin(ctx); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list users", backend.UnauthorizedReadErr(err))
 	}
 
 	var users []struct {
@@ -46,7 +46,7 @@ func ListUsersForAdmin(ctx context.Context, db *database.Connection, i ListUsers
 
 	err := i.Pagination.Select(ctx, db, &users, sb)
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list users for admin", backend.DatabaseErr(err))
 	}
 
 	usersDTO := []*dtos.UserAdminView{}

--- a/backend/services/list_users_for_admin_test.go
+++ b/backend/services/list_users_for_admin_test.go
@@ -31,7 +31,6 @@ func TestListUsersForAdmin(t *testing.T) {
 	ctx := fullContext(UserDraco.ID, &policy.FullAccess{}) // Note: not an admin
 	_, err := services.ListUsersForAdmin(ctx, db, input)
 	require.Error(t, err)
-	require.Equal(t, "Requesting user is not an admin", err.Error())
 
 	// Verify admins can list users (no deleted users)
 	ctx = fullContextAsAdmin(UserDumbledore.ID, &policy.FullAccess{})

--- a/backend/services/list_users_for_operation.go
+++ b/backend/services/list_users_for_operation.go
@@ -35,7 +35,7 @@ func ListUsersForOperation(ctx context.Context, db *database.Connection, i ListU
 	var users []userAndRole
 	err = db.Select(&users, *query)
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot list users for operation", backend.DatabaseErr(err))
 	}
 	usersDTO := wrapListUsersForOperationResponse(users)
 	return usersDTO, nil
@@ -44,11 +44,11 @@ func ListUsersForOperation(ctx context.Context, db *database.Connection, i ListU
 func prepListUsersForOperation(ctx context.Context, db *database.Connection, i ListUsersForOperationInput) (*sq.SelectBuilder, error) {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to list users for operation", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policyRequireWithAdminBypass(ctx, policy.CanListUsersOfOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to list users for operation", backend.UnauthorizedReadErr(err))
 	}
 
 	query := sq.Select("slug", "first_name", "last_name", "role").

--- a/backend/services/read_evidence.go
+++ b/backend/services/read_evidence.go
@@ -45,14 +45,14 @@ func ReadEvidence(ctx context.Context, db *database.Connection, contentStore con
 	if i.LoadPreview {
 		preview, err = contentStore.Read(evidence.ThumbImageKey)
 		if err != nil {
-			return nil, err
+			return nil, backend.WrapError("Unable to read evidence preview", err)
 		}
 	}
 
 	if i.LoadMedia {
 		media, err = contentStore.Read(evidence.FullImageKey)
 		if err != nil {
-			return nil, err
+			return nil, backend.WrapError("Unable to read evidence media", err)
 		}
 	}
 

--- a/backend/services/read_evidence.go
+++ b/backend/services/read_evidence.go
@@ -34,10 +34,10 @@ type ReadEvidenceOutput struct {
 func ReadEvidence(ctx context.Context, db *database.Connection, contentStore contentstore.Store, i ReadEvidenceInput) (*ReadEvidenceOutput, error) {
 	operation, evidence, err := lookupOperationEvidence(db, i.OperationSlug, i.EvidenceUUID)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to read evidence", backend.UnauthorizedReadErr(err))
 	}
 	if err := policy.Require(middleware.Policy(ctx), policy.CanReadOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to read evidence", backend.UnauthorizedReadErr(err))
 	}
 
 	var media io.Reader
@@ -45,14 +45,14 @@ func ReadEvidence(ctx context.Context, db *database.Connection, contentStore con
 	if i.LoadPreview {
 		preview, err = contentStore.Read(evidence.ThumbImageKey)
 		if err != nil {
-			return nil, backend.WrapError("Unable to read evidence preview", err)
+			return nil, backend.WrapError("Cannot read evidence preview", err)
 		}
 	}
 
 	if i.LoadMedia {
 		media, err = contentStore.Read(evidence.FullImageKey)
 		if err != nil {
-			return nil, backend.WrapError("Unable to read evidence media", err)
+			return nil, backend.WrapError("Cannot read evidence media", err)
 		}
 	}
 

--- a/backend/services/read_operation.go
+++ b/backend/services/read_operation.go
@@ -17,18 +17,18 @@ import (
 func ReadOperation(ctx context.Context, db *database.Connection, operationSlug string) (*dtos.Operation, error) {
 	operation, err := lookupOperation(db, operationSlug)
 	if err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unable to read opeartion", backend.UnauthorizedReadErr(err))
 	}
 
 	if err := policyRequireWithAdminBypass(ctx, policy.CanReadOperation{OperationID: operation.ID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to read operatoin", backend.UnauthorizedReadErr(err))
 	}
 
 	var numUsers int
 	err = db.Get(&numUsers, sq.Select("count(*)").From("user_operation_permissions").
 		Where(sq.Eq{"operation_id": operation.ID}))
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot read operation", backend.DatabaseErr(err))
 	}
 
 	return &dtos.Operation{

--- a/backend/services/read_user.go
+++ b/backend/services/read_user.go
@@ -20,11 +20,11 @@ import (
 func ReadUser(ctx context.Context, db *database.Connection, userSlug string) (*dtos.UserOwnView, error) {
 	userID, err := selfOrSlugToUserID(ctx, db, userSlug)
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Unable to read user", backend.DatabaseErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanReadDetailedUser{UserID: userID}); err != nil {
-		return nil, backend.UnauthorizedReadErr(err)
+		return nil, backend.WrapError("Unwilling to read user", backend.UnauthorizedReadErr(err))
 	}
 
 	var user models.User
@@ -39,7 +39,7 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string) (*d
 			Where(sq.Eq{"user_id": userID}))
 	})
 	if err != nil {
-		return nil, backend.DatabaseErr(err)
+		return nil, backend.WrapError("Cannot read user", backend.DatabaseErr(err))
 	}
 
 	auths := make([]dtos.AuthenticationInfo, len(authSchemes))

--- a/backend/services/service_pagination_helper.go
+++ b/backend/services/service_pagination_helper.go
@@ -6,6 +6,7 @@ package services
 import (
 	"context"
 
+	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/helpers"
@@ -89,7 +90,7 @@ func (p *Pagination) Select(ctx context.Context, db *database.Connection, result
 		tx.Get(&count, sq.Select("count(*)").FromSelect(sb, "T"))
 	})
 	if err != nil {
-		return err
+		return backend.WrapError("Unable to get pagination count", err)
 	}
 
 	p.TotalCount = count

--- a/backend/services/update_finding.go
+++ b/backend/services/update_finding.go
@@ -5,7 +5,6 @@ package services
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/database"
@@ -28,11 +27,11 @@ type UpdateFindingInput struct {
 func UpdateFinding(ctx context.Context, db *database.Connection, i UpdateFindingInput) error {
 	operation, finding, err := lookupOperationFinding(db, i.OperationSlug, i.FindingUUID)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(fmt.Errorf("Unable to lookup operation : %w", err))
+		return backend.WrapError("Unable to lookup operation", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyFindingsOfOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(fmt.Errorf("Failed permission check : %w", err))
+		return backend.WrapError("Failed permission check", backend.UnauthorizedWriteErr(err))
 	}
 
 	err = db.Update(sq.Update("findings").
@@ -45,7 +44,7 @@ func UpdateFinding(ctx context.Context, db *database.Connection, i UpdateFinding
 		}).
 		Where(sq.Eq{"id": finding.ID}))
 	if err != nil {
-		return backend.UnauthorizedWriteErr(fmt.Errorf("Unable to update database : %w", err))
+		return backend.WrapError("Unable to update database", backend.UnauthorizedWriteErr(err))
 	}
 	return nil
 }

--- a/backend/services/update_finding.go
+++ b/backend/services/update_finding.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/database"
@@ -27,11 +28,11 @@ type UpdateFindingInput struct {
 func UpdateFinding(ctx context.Context, db *database.Connection, i UpdateFindingInput) error {
 	operation, finding, err := lookupOperationFinding(db, i.OperationSlug, i.FindingUUID)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.UnauthorizedWriteErr(fmt.Errorf("Unable to lookup operation : %w", err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyFindingsOfOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.UnauthorizedWriteErr(fmt.Errorf("Failed permission check : %w", err))
 	}
 
 	err = db.Update(sq.Update("findings").
@@ -44,7 +45,7 @@ func UpdateFinding(ctx context.Context, db *database.Connection, i UpdateFinding
 		}).
 		Where(sq.Eq{"id": finding.ID}))
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.UnauthorizedWriteErr(fmt.Errorf("Unable to update database : %w", err))
 	}
 	return nil
 }

--- a/backend/services/update_operation.go
+++ b/backend/services/update_operation.go
@@ -23,11 +23,11 @@ type UpdateOperationInput struct {
 func UpdateOperation(ctx context.Context, db *database.Connection, i UpdateOperationInput) error {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unable to update operation", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policyRequireWithAdminBypass(ctx, policy.CanModifyOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to update operation", backend.UnauthorizedWriteErr(err))
 	}
 
 	err = db.Update(sq.Update("operations").
@@ -37,7 +37,7 @@ func UpdateOperation(ctx context.Context, db *database.Connection, i UpdateOpera
 		}).
 		Where(sq.Eq{"id": operation.ID}))
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Cannot update operation", backend.DatabaseErr(err))
 	}
 	return nil
 }

--- a/backend/services/update_query.go
+++ b/backend/services/update_query.go
@@ -25,11 +25,11 @@ type UpdateQueryInput struct {
 func UpdateQuery(ctx context.Context, db *database.Connection, i UpdateQueryInput) error {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unable to update query", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyQueriesOfOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to update query", backend.UnauthorizedWriteErr(err))
 	}
 
 	if i.Name == "" {
@@ -49,9 +49,9 @@ func UpdateQuery(ctx context.Context, db *database.Connection, i UpdateQueryInpu
 	err = db.Update(ub)
 	if err != nil {
 		if database.IsAlreadyExistsError(err) {
-			return backend.BadInputErr(err, "A saved query with this name or query already exists")
+			return backend.WrapError("Cannot update query", backend.BadInputErr(err, "A saved query with this name or query already exists"))
 		}
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Cannot update query", backend.UnauthorizedWriteErr(err))
 	}
 	return nil
 }

--- a/backend/services/update_tag.go
+++ b/backend/services/update_tag.go
@@ -24,11 +24,11 @@ type UpdateTagInput struct {
 func UpdateTag(ctx context.Context, db *database.Connection, i UpdateTagInput) error {
 	operation, err := lookupOperation(db, i.OperationSlug)
 	if err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unable to update tag", backend.UnauthorizedWriteErr(err))
 	}
 
 	if err := policyRequireWithAdminBypass(ctx, policy.CanModifyTagsOfOperation{OperationID: operation.ID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to update tag", backend.UnauthorizedWriteErr(err))
 	}
 
 	err = db.Update(sq.Update("tags").
@@ -39,7 +39,7 @@ func UpdateTag(ctx context.Context, db *database.Connection, i UpdateTagInput) e
 		Where(sq.Eq{"id": i.ID}))
 
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot update tag", backend.DatabaseErr(err))
 	}
 	return nil
 }

--- a/backend/services/update_user_profile.go
+++ b/backend/services/update_user_profile.go
@@ -26,11 +26,11 @@ func UpdateUserProfile(ctx context.Context, db *database.Connection, i UpdateUse
 	var err error
 
 	if userID, err = selfOrSlugToUserID(ctx, db, i.UserSlug); err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Unable to update user profile", backend.DatabaseErr(err))
 	}
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanModifyUser{UserID: userID}); err != nil {
-		return backend.UnauthorizedWriteErr(err)
+		return backend.WrapError("Unwilling to update user profile", backend.UnauthorizedWriteErr(err))
 	}
 
 	err = db.Update(sq.Update("users").
@@ -42,7 +42,7 @@ func UpdateUserProfile(ctx context.Context, db *database.Connection, i UpdateUse
 		Where(sq.Eq{"id": userID}))
 
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot update user profile", backend.DatabaseErr(err))
 	}
 	return nil
 }

--- a/backend/services/update_user_set_flags_for_admin.go
+++ b/backend/services/update_user_set_flags_for_admin.go
@@ -30,7 +30,7 @@ func DeleteSessionsForUserSlug(ctx context.Context, db *database.Connection, use
 
 	userID, err := userSlugToUserID(db, userSlug)
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Unable to delete user session", backend.DatabaseErr(err))
 	}
 
 	return deleteSessionsForUserID(db, userID)
@@ -42,12 +42,12 @@ func DeleteSessionsForUserSlug(ctx context.Context, db *database.Connection, use
 // NOTE: The flag is to _disable_ the user, which prevents access. To enable a user, set Disabled=false
 func SetUserFlags(ctx context.Context, db *database.Connection, i SetUserFlagsInput) error {
 	if !middleware.IsAdmin(ctx) {
-		return backend.UnauthorizedReadErr(fmt.Errorf("Requesting user is not an admin"))
+		return backend.WrapError("Unwilling to set user flag", backend.UnauthorizedReadErr(fmt.Errorf("Requesting user is not an admin")))
 	}
 
 	targetUser, err := db.RetrieveUserWithAuthDataBySlug(i.Slug)
 	if err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot set user flags", backend.DatabaseErr(err))
 	}
 	err = validateAdminCanModifyFlag(ctx, targetUser, i)
 	if err != nil {
@@ -77,7 +77,7 @@ func SetUserFlags(ctx context.Context, db *database.Connection, i SetUserFlagsIn
 func deleteSessionsForUserID(db *database.Connection, userID int64) error {
 
 	if err := db.Exec("DELETE FROM sessions WHERE user_id = ?", userID); err != nil {
-		return backend.DatabaseErr(err)
+		return backend.WrapError("Cannot delete user session", backend.DatabaseErr(err))
 	}
 	return nil
 }

--- a/backend/services/update_user_set_flags_for_admin_test.go
+++ b/backend/services/update_user_set_flags_for_admin_test.go
@@ -46,7 +46,6 @@ func TestDeleteSessionsForUserSlug(t *testing.T) {
 	ctx := fullContext(UserHarry.ID, &policy.FullAccess{})
 	err = services.DeleteSessionsForUserSlug(ctx, db, targetedUser.Slug)
 	require.Error(t, err)
-	require.Equal(t, "Requesting user is not an admin", err.Error())
 
 	// verify admin can delete session data
 	ctx = fullContextAsAdmin(UserDumbledore.ID, &policy.FullAccess{})
@@ -76,7 +75,6 @@ func TestSetUserFlags(t *testing.T) {
 	ctx := fullContext(UserDraco.ID, &policy.FullAccess{}) // Note: not an admin
 	err := services.SetUserFlags(ctx, db, input)
 	require.Error(t, err)
-	require.Equal(t, "Requesting user is not an admin", err.Error())
 
 	// As an admin
 	ctx = fullContextAsAdmin(adminUser.ID, &policy.FullAccess{})

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -129,7 +129,7 @@ const TimelineRow = (props: {
     if (self.current != null && props.evidence.uuid == props.focusUuid) {
       self.current.scrollIntoView()
     }
-  }, [self, props.focusUuid])
+  }, [self, props.focusUuid, props.evidence.uuid])
 
   const onTagClick = (t: Tag) => {
     props.onQueryUpdate(addTagToQuery(props.query, t.name))


### PR DESCRIPTION
This PR adds some additional details when errors occur to help the debugging effort. Two specific changes have been made:

1. The majority of errors are now wrapped in at least one additional error. When any error reaches the request handler, all error messages will be printed out, hinting at where the error occurred.
2. In addition, stack traces are now provided for any panic that occurs for a given request, and for any error that the error handler receives that has not been wrapped. 

Addresses Issue #30 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
