### PR TITLE
TagTable usability improvements

### DIFF
--- a/frontend/src/components/table/index.tsx
+++ b/frontend/src/components/table/index.tsx
@@ -5,23 +5,48 @@ import * as React from 'react'
 import classnames from 'classnames/bind'
 const cx = classnames.bind(require('./stylesheet'))
 
+export const SortAsc = 'asc'
+export const SortDesc = 'desc'
+
+export type SortDirection = typeof SortAsc | typeof SortDesc | undefined
+
+export type ColumnData = {
+  label: string,
+  title: string,
+  sortDirection?: SortDirection,
+  clickable?: boolean
+}
+
 export default (props: {
   children: React.ReactNode,
   className?: string,
-  columns: Array<string | {label: string, title: string}>,
+  columns: Array<string | ColumnData>,
+  onColumnClicked?: (colIndex: number)=>void,
 }) => (
-  <table className={cx('root', props.className)}>
-    <thead>
-      <tr>
-        {props.columns.map((column, idx) => (
-          typeof (column) === 'object'
-            ? <th key={`${column.label}-${idx}`} title={column.title}>{column.label}</th>
-            : <th key={`${column}-${idx}`}>{column}</th>
-        ))}
-      </tr>
-    </thead>
-    <tbody>
-      {props.children}
-    </tbody>
-  </table>
-)
+    <table className={cx('root', props.className)}>
+      <thead>
+        <tr>
+          {props.columns.map((column, idx) => {
+            if (typeof (column) === 'object') {
+              const args = {
+                key: `${column.label}-${idx}`,
+                title: column.title,
+                style: column.clickable ? { cursor: "pointer" } : {},
+                onClick: () => (column.clickable && props.onColumnClicked) ? props.onColumnClicked(idx) : undefined
+              }
+              return (
+                <th {...args}>
+                  {column.label}
+                  {column.sortDirection ? <span className={cx('arrow', column.sortDirection == SortAsc ? 'asc' : 'desc')}></span> : null}
+                </th>
+              )
+            }
+            return <th key={`${column}-${idx}`}>{column}</th>
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {props.children}
+      </tbody>
+    </table>
+  )

--- a/frontend/src/components/table/stylesheet.styl
+++ b/frontend/src/components/table/stylesheet.styl
@@ -21,3 +21,22 @@
     background: $background
     transition: background 100ms
     &:hover { background: $lighter-background }
+
+  $arrow-size = 5px
+  .arrow
+    position: relative
+    &.asc:after
+      content: ""
+      position: absolute
+      top: 12px - $arrow-size
+      left: 12px - $arrow-size
+      border: $arrow-size solid transparent
+      border-top-color: $foreground
+
+    &.desc:after
+      content: ""
+      position: absolute
+      top: 6px - $arrow-size
+      left: 12px - $arrow-size
+      border: $arrow-size solid transparent
+      border-bottom-color: $foreground

--- a/frontend/src/pages/operation_edit/tag_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/tag_editor/index.tsx
@@ -11,11 +11,15 @@ import {default as Button, ButtonGroup} from 'src/components/button'
 import {getTags} from 'src/services'
 import {useWiredData, useModal, renderModals} from 'src/helpers'
 
+// @ts-ignore - npm package @types/react-router-dom needs to be updated (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40131)
+import { useHistory } from 'react-router-dom'
+
 const TagTable = (props: {
   operationSlug: string,
   tags: Array<TagWithUsage>,
   onUpdate: () => void,
 }) => {
+  const history = useHistory()
   const editTagModal = useModal<{ tag: TagWithUsage }>(modalProps => (
     <EditTagModal {...modalProps} operationSlug={props.operationSlug} onEdited={props.onUpdate} />
   ))
@@ -27,7 +31,7 @@ const TagTable = (props: {
     <Table columns={['Tag', '# Evidence Attached To', 'Actions']}>
       {props.tags.map(tag => (
         <tr key={tag.name}>
-          <td><Tag name={tag.name} color={tag.colorName} /></td>
+          <td><Tag name={tag.name} color={tag.colorName} onClick={() => history.push(`/operations/${props.operationSlug}/evidence?q=tag:${tag.name}`)}/></td>
           <td>{tag.evidenceCount}</td>
           <td>
             <ButtonGroup>

--- a/frontend/src/pages/operation_edit/tag_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/tag_editor/index.tsx
@@ -3,16 +3,22 @@
 
 import * as React from 'react'
 import SettingsSection from 'src/components/settings_section'
-import Table from 'src/components/table'
+import { default as Table, SortAsc, SortDesc, SortDirection, ColumnData } from 'src/components/table'
 import Tag from 'src/components/tag'
-import {DeleteTagModal, EditTagModal} from './modals'
+import { DeleteTagModal, EditTagModal } from './modals'
 import { TagWithUsage } from 'src/global_types'
-import {default as Button, ButtonGroup} from 'src/components/button'
-import {getTags} from 'src/services'
-import {useWiredData, useModal, renderModals} from 'src/helpers'
+import { default as Button, ButtonGroup } from 'src/components/button'
+import { getTags } from 'src/services'
+import { useWiredData, useModal, renderModals } from 'src/helpers'
 
 // @ts-ignore - npm package @types/react-router-dom needs to be updated (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40131)
 import { useHistory } from 'react-router-dom'
+
+type compareableFunc = (l: any, r: any) => number
+
+const sortNone: compareableFunc = (a: any, b: any) => 0
+const sortNums: compareableFunc = (a: TagWithUsage, b: TagWithUsage) => a.evidenceCount - b.evidenceCount
+const sortTags: compareableFunc = (a: TagWithUsage, b: TagWithUsage) => a.name.localeCompare(b.name)
 
 const TagTable = (props: {
   operationSlug: string,
@@ -27,16 +33,37 @@ const TagTable = (props: {
     <DeleteTagModal {...modalProps} operationSlug={props.operationSlug} onDeleted={props.onUpdate} />
   ))
 
+  // React has a special meaning for passing functions into useState, so re-wrapping the function to
+  // simply store the desired sorting function (we do the same with the setSortFunc value)
+  const [sortFunc, setSortFunc] = React.useState<compareableFunc>(() => sortNone)
+
+  const [columns, setColumns] = React.useState<Array<ColumnData & { compareVia: compareableFunc }>>([
+    { title: '', label: 'Tag', clickable: true, compareVia: sortTags },
+    { title: '', label: '# Evidence Attached To', clickable: true, compareVia: sortNums },
+    { title: '', label: 'Actions', compareVia: sortNone },
+  ])
+
+  const updateColumnSorting = (index: number) => {
+    const sortDirections: Array<{ compare: compareableFunc, dir: SortDirection }> = [
+      { dir: SortAsc, compare: columns[index].compareVia },
+      { dir: SortDesc, compare: (a, b) => columns[index].compareVia(b, a) },
+      { dir: undefined, compare: sortNone }
+    ]
+    const matchIndex = (sortDirections.findIndex(x => x.dir == columns[index].sortDirection) + 1) % sortDirections.length
+    setColumns(columns.map((col, idx) => ({ ...col, sortDirection: (idx == index) ? sortDirections[matchIndex].dir : undefined })))
+    setSortFunc(() => sortDirections[matchIndex].compare)
+  }
+
   return <>
-    <Table columns={['Tag', '# Evidence Attached To', 'Actions']}>
-      {props.tags.map(tag => (
+    <Table columns={columns} onColumnClicked={updateColumnSorting}>
+      {[...props.tags].sort(sortFunc).map(tag => (
         <tr key={tag.name}>
-          <td><Tag name={tag.name} color={tag.colorName} onClick={() => history.push(`/operations/${props.operationSlug}/evidence?q=tag:${tag.name}`)}/></td>
+          <td><Tag name={tag.name} color={tag.colorName} onClick={() => history.push(`/operations/${props.operationSlug}/evidence?q=tag:${tag.name}`)} /></td>
           <td>{tag.evidenceCount}</td>
           <td>
             <ButtonGroup>
-              <Button small onClick={() => editTagModal.show({tag})}>Edit</Button>
-              <Button small onClick={() => deleteTagModal.show({tag})}>Delete</Button>
+              <Button small onClick={() => editTagModal.show({ tag })}>Edit</Button>
+              <Button small onClick={() => deleteTagModal.show({ tag })}>Delete</Button>
             </ButtonGroup>
           </td>
         </tr>
@@ -50,7 +77,7 @@ const TagTable = (props: {
 export default (props: {
   operationSlug: string,
 }) => {
-  const wiredTags = useWiredData(React.useCallback(() => getTags({operationSlug: props.operationSlug}), [props.operationSlug]))
+  const wiredTags = useWiredData(React.useCallback(() => getTags({ operationSlug: props.operationSlug }), [props.operationSlug]))
 
   return (
     <SettingsSection title="Operation Tags">


### PR DESCRIPTION
This PR adds support  for sorting tables by column (generally), and specifically enables this sorting, plus jumping to a filtered evidence view when clicking on a tag in the tag edit menu.

Addresses Issue: #34

Changes:

* The `Table` component can now, given an object (rather than an array) of columns, both render a sorting arrow, and communicate back if a header has been clicked.
* The `TagTable` component now provides a mechanism to indicate to the `Table` component which column is sorted, and sorts a copy of the provided data (to allow returning to an unsorted state)

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
