### PR TITLE
Bugfix: support for multi-word tags while clicking on them in the operations settings menu

### DIFF
--- a/frontend/src/pages/operation_edit/tag_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/tag_editor/index.tsx
@@ -58,7 +58,7 @@ const TagTable = (props: {
     <Table columns={columns} onColumnClicked={updateColumnSorting}>
       {[...props.tags].sort(sortFunc).map(tag => (
         <tr key={tag.name}>
-          <td><Tag name={tag.name} color={tag.colorName} onClick={() => history.push(`/operations/${props.operationSlug}/evidence?q=tag:${tag.name}`)} /></td>
+          <td><Tag name={tag.name} color={tag.colorName} onClick={() => history.push(`/operations/${props.operationSlug}/evidence?q=tag:"${tag.name}"`)} /></td>
           <td>{tag.evidenceCount}</td>
           <td>
             <ButtonGroup>


### PR DESCRIPTION
This PR corrects behavior a bug introduced in PR #36. Specifically, when a multi-word tag is clicked on, the filter did not wrap the tag name in quotes, preventing proper filtering.

Addresses Issue #37 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
