### PR TITLE
Remove syntax highlighting for markdown renders

### DIFF
--- a/frontend/src/components/markdown_renderer/sync_renderer/index.tsx
+++ b/frontend/src/components/markdown_renderer/sync_renderer/index.tsx
@@ -5,21 +5,8 @@ import * as React from 'react'
 import classnames from 'classnames/bind'
 // @ts-ignore - module react-markdown does not have associated types (gets imported as any type)
 import ReactMarkdown from 'react-markdown'
-// @ts-ignore - module react-syntax-highlighter does not have associated types (gets imported as any type)
-import SyntaxHighlighter from 'react-syntax-highlighter'
-const cx = classnames.bind(require('./stylesheet'))
 
-const CodeBlock = (props: {
-  language: string,
-  value: string,
-}) => (
-  <SyntaxHighlighter
-    className={cx('code-block')}
-    language={props.language}
-    children={props.value}
-    style={{}}
-  />
-)
+const cx = classnames.bind(require('./stylesheet'))
 
 export default (props: {
   children: string
@@ -27,6 +14,5 @@ export default (props: {
   <ReactMarkdown
     className={cx('markdown')}
     source={props.children}
-    renderers={{code: CodeBlock}}
   />
 )


### PR DESCRIPTION
This PR removes the feature to render codeblocks in markdown. Code blocks within markdown are still supported, but are rendered as if they were not in a code block.

i.e. markdown that looks like this:
```md
   ```java
      public static void main(String[] args) {
          System.out.println("Yo!");
      }
   ``
```
will look like:
public static void main(String[] args) {
&nbsp;&nbsp;System.out.println("Yo!");
}

This has been done to improve the responsiveness of loading markdown descriptions, which generally don't contain codeblocks in the first place. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
