### PR TITLE
Move overview icon below edit icon (rather than to the left)

### DIFF
--- a/frontend/src/pages/operation_show/layout/sidebar/stylesheet.styl
+++ b/frontend/src/pages/operation_show/layout/sidebar/stylesheet.styl
@@ -49,8 +49,8 @@
 
 .overview
   position: absolute
-  top: 0
-  right: 40px
+  top: 30px
+  right: 10px
   width: 25px
   height: @width
   background-image: url('./examine.svg')


### PR DESCRIPTION
This PR moves the operation overview icon while in the timeline display directly below the edit icon (pencil), rather than to the left of this icon. This fixes an issue where the overview icon would overlap the operation name in the timeline.

Addresses Issue #44 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
