### PR TITLE
Add ability to toggle best-fit vs standard fit

### DIFF
--- a/frontend/src/components/help/index.tsx
+++ b/frontend/src/components/help/index.tsx
@@ -59,11 +59,12 @@ export default (props: {
 export type KeyboardShortcut = {
   keys: Array<string>
   description: string
+  uniqueKey?: string
 }
 
 const commonKeyboardShortcuts = [
-  { keys: ["?"], description: "Open this help menu" },
-  { keys: ["Escape"], description: "Close this window" },
+  { keys: ["?"], description: "Open this help menu", uniqueKey: "stdhelp-?" },
+  { keys: ["Escape"], description: "Close this window", uniqueKey: "stdhelp-Escape"},
 ]
 
 export const HelpModal = (props: {
@@ -88,7 +89,7 @@ export const HelpModal = (props: {
           <h1>Keyboard Shortcuts</h1>
           {props.shortcuts
             .concat(commonKeyboardShortcuts)
-            .map(shortcut => <KeyboardShortcutKey key={shortcut.keys[0]} shortcut={shortcut} />)
+            .map(shortcut => <KeyboardShortcutKey key={shortcut.uniqueKey ? shortcut.uniqueKey : shortcut.keys[0]} shortcut={shortcut} />)
           }
         </div>
       }

--- a/frontend/src/components/lightbox/index.tsx
+++ b/frontend/src/components/lightbox/index.tsx
@@ -3,17 +3,18 @@
 
 import * as React from 'react'
 import classnames from 'classnames/bind'
-import {createPortal} from 'react-dom'
+import { createPortal } from 'react-dom'
 const cx = classnames.bind(require('./stylesheet'))
 
 export default (props: {
   children: React.ReactNode,
   isOpen: boolean,
+  showToggle?: boolean
   onRequestClose: () => void,
 }) => {
   const [exists, setExists] = React.useState<boolean>(false)
   const [animating, setAnimating] = React.useState<boolean>(true)
-
+  const [full, setFull] = React.useState<boolean>(true)
 
   React.useEffect(() => {
     if (props.isOpen) {
@@ -28,6 +29,7 @@ export default (props: {
 
   const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') props.onRequestClose()
+    if (e.key === 'z' || e.key === 'Z') setFull(!full)
   }
 
   React.useEffect(() => {
@@ -39,7 +41,7 @@ export default (props: {
   return (
     createPortal((
       <div className={cx('root', animating ? 'animating' : 'open')} onClick={props.onRequestClose}>
-        <div className={cx('content')} onClick={e => e.stopPropagation()}>
+        <div className={cx('content', full ? "full" : "fit")} onClick={e => e.stopPropagation()}>
           {props.children}
         </div>
       </div>

--- a/frontend/src/components/lightbox/stylesheet.styl
+++ b/frontend/src/components/lightbox/stylesheet.styl
@@ -19,12 +19,27 @@
   max-width: 95%
   transform: translate(-50%, -50%)
   transition: all 200ms
-  box-shadow: 0 0 40px 0 #000
   background: $background
   overflow: auto
+
+  &.fit
+    transition: all 0ms
+    background: transparent
+    box-shadow: initial
 
 .animating
   opacity: 0
 
 .open
   opacity: 1
+
+.fit
+  img
+    display: block
+    width: 95vw
+    height: 95vh
+    object-fit: contain
+
+.full
+  img
+    display: block

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -222,4 +222,5 @@ export const KeyboardShortcuts = [
   { keys: ["Enter"], description: "Open evidence large view" },
   { keys: ["Escape"], description: "Close evidence large view" },
   { keys: [" "], description: "Toggle evidence large view" },
+  { keys: ["z", "Z"], description: "Toggle Best Fit vs standard view" },
 ]

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -99,7 +99,8 @@ export default (props: {
         shortcuts={KeyboardShortcuts}
       />
     </div>
-    <Lightbox isOpen={quicklookVisible} onRequestClose={() => setQuicklookVisible(false)}>
+    <Lightbox showToggle={activeEvidence.contentType == "image"}
+      isOpen={quicklookVisible} onRequestClose={() => setQuicklookVisible(false)}>
       <div ref={lightboxRef}>
         <EvidencePreview
           operationSlug={props.operationSlug}


### PR DESCRIPTION
This PR adds the ability to change the "fit" of image evidence, while in lightbox, between two modes: a "Best fit" and a "full-size" By default, images will first be presented in full-size, but can be toggled to do a best fit. 

Full-size images are exactly as they are now. The image will be scrollable if it's too big for the browser. Likewise, if it's a small image, the full size will be small.

Best-fit acts like a zoom-in, or a zoom-out, depending on the source image. For large images, the image will be scaled down to fit the maximum area of the view. For small images, the image will be scaled up to have a zoomed-in view.

Addresses Issue #50 

User guide:
To toggle, press the `z` key (upper or lower case). fit is kept between images, if navigating with the keyboard

Changes:
Other than the above changes, this PR also:
1. Removes the box shadow on the lightbox. Due to the way the zoom-in works, the container around the image is generally larger than the best-fit image. If the box shadow is kept, it actually shadows the wrong element, resulting in a weird effect. 
2. For images only, makes the lightbox background transparent, due to the above reason

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
