### PR TITLE
Trim search strings of leading/ending whitespace

### DIFF
--- a/frontend/src/pages/operation_show/evidence_list/index.tsx
+++ b/frontend/src/pages/operation_show/evidence_list/index.tsx
@@ -45,7 +45,7 @@ export default (props: RouteComponentProps<{ slug: string }>) => {
 
   const navigate = (view: ViewName, query: string) => {
     let path = `/operations/${slug}/${view}`
-    if (query != '') path += `?q=${encodeURIComponent(query)}`
+    if (query != '') path += `?q=${encodeURIComponent(query.trim())}`
     props.history.push(path)
   }
 

--- a/frontend/src/pages/operation_show/finding_list/index.tsx
+++ b/frontend/src/pages/operation_show/finding_list/index.tsx
@@ -23,7 +23,7 @@ export default (props: RouteComponentProps<{slug: string}>) => {
 
   const navigate = (view: ViewName, query: string) => {
     let path = `/operations/${slug}/${view}`
-    if (query != '') path += `?q=${encodeURIComponent(query)}`
+    if (query != '') path += `?q=${encodeURIComponent(query.trim())}`
     props.history.push(path)
   }
 

--- a/frontend/src/pages/operation_show/finding_show/index.tsx
+++ b/frontend/src/pages/operation_show/finding_show/index.tsx
@@ -68,7 +68,7 @@ export default (props: RouteComponentProps<{slug: string, uuid: string}>) => {
               'Remove From Finding': evidence => removeEvidenceFromFindingModal.show({evidence, finding}),
               'Edit': evidence => editEvidenceModal.show({evidence}),
             }}
-            onQueryUpdate={query => props.history.push(`/operations/${slug}/evidence?q=${encodeURIComponent(query)}`)}
+            onQueryUpdate={query => props.history.push(`/operations/${slug}/evidence?q=${encodeURIComponent(query.trim())}`)}
             operationSlug={slug}
             query=""
           />


### PR DESCRIPTION
This PR trims the search string when searching. All leading and ending white space will be removed. White space between terms is preserved.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of it s copyright owner.
