### PR TITLE
Start in best fit mode

### DIFF
--- a/frontend/src/components/lightbox/index.tsx
+++ b/frontend/src/components/lightbox/index.tsx
@@ -14,7 +14,7 @@ export default (props: {
 }) => {
   const [exists, setExists] = React.useState<boolean>(false)
   const [animating, setAnimating] = React.useState<boolean>(true)
-  const [full, setFull] = React.useState<boolean>(true)
+  const [full, setFull] = React.useState<boolean>(false)
 
   React.useEffect(() => {
     if (props.isOpen) {


### PR DESCRIPTION
This PR adjusts how default image zoom works. Rather in starting in "full" mode, this PR will opt to start in "best fit" mode, for a generally better experience.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.