### PR TITLE
Cache Busting Revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ run-backend: clean-backend rerun-backend
 rerun-backend:
 	docker-compose up --build
 
+.PHONY: run-prod
+run-prod:
+	docker-compose -f docker-compose-prod.yml down
+	docker-compose -f docker-compose-prod.yml up --build
+
 ##### Helpers
 
 # view-backend enters the docker container running the backend

--- a/dev_seed_data/z01_seed_data.sql
+++ b/dev_seed_data/z01_seed_data.sql
@@ -1,0 +1,311 @@
+
+-- encrypted bcrypt password (Plain Text: "password")	
+-- equivalent Go code: bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)	
+
+SET @defaultPassword = '$2a$10$MLooRpCcdyyxoXwe3ZiCFuQZfsGeVC7TPCSyYhTs8Bl/sFPd4K67W';	
+
+INSERT INTO users	
+    (slug, first_name, last_name, email, `admin`) 	
+VALUES	
+      ('adefaultuser', 'Alice',   'DefaultUser', 'adefaultuser@example.com', true)	
+    , ('bsnooper',     'Bob',     'Snooper',     'bsnooper@example.com', false)	
+    , ('cother',       'Carl',    'Other',       'cother@example.com', false)	
+    , ('dother',       'Debbie',  'Other',       'dother@example.com', false)	
+    , ('eother',       'Edith',   'Other',       'eother@example.com', false)	
+    , ('fother',       'Fred',    'Other',       'fother@example.com', false)	
+    , ('gother',       'Ginna',   'Other',       'gother@example.com', false)	
+    , ('hother',       'Hazel',   'Other',       'hother@example.com', false)	
+    , ('iother',       'Ivy',     'Other',       'iother@example.com', false)	
+    , ('jother',       'Justin',  'Other',       'jother@example.com', false)	
+    , ('kother',       'Kevin',   'Other',       'kother@example.com', false)	
+    , ('lother',       'Liz',     'Other',       'lother@example.com', false)	
+    , ('mother',       'Martin',  'Other',       'mother@example.com', false)	
+    , ('nother',       'Nick',    'Other',       'nother@example.com', false)	
+    , ('oother',       'Ophelia', 'Other',       'oother@example.com', false)	
+    , ('pother',       'Paul',    'Other',       'pother@example.com', false)	
+    , ('qother',       'Quinton', 'Other',       'qother@example.com', false)	
+    , ('rother',       'Rachel',  'Other',       'rother@example.com', false)	
+    , ('tother',       'Tess',    'Other',       'tother@example.com', false)	
+    , ('uother',       'Ursula',  'Other',       'uother@example.com', false)	
+    , ('vother',       'Vera',    'Other',       'vother@example.com', false)	
+    , ('wother',       'Winston', 'Other',       'wother@example.com', false)	
+    , ('xother',       'Xavier',  'Other',       'xother@example.com', false)	
+    , ('yother',       'Yavonne', 'Other',       'yother@example.com', false)	
+    , ('zother',       'Zoey',    'Other',       'zother@example.com', false)	
+    , ('smoker',       'Smoke',   'Tester',      'smoker', false)	
+    ;	
+
+SET @alice_uid = 1;	
+SET @bob_uid = 2;	
+SET @carl_uid = 3;	
+SET @debbie_uid = 4;	
+SET @edith_uid = 5;	
+SET @fred_uid = 6;	
+SET @ginna_uid = 7;	
+SET @hazel_uid = 8;	
+SET @ivy_uid = 9;	
+SET @justin_uid = 10;	
+SET @kevin_uid = 11;	
+SET @liz_uid = 12;	
+SET @martin_uid = 13;	
+SET @nick_uid = 14;	
+SET @ophelia_uid = 15;	
+SET @paul_uid = 16;	
+SET @quinton_uid = 17;	
+SET @rachel_uid = 18;	
+SET @tess_uid = 19;	
+SET @ursula_uid = 20;	
+SET @vera_uid = 21;	
+SET @winston_uid = 22;	
+SET @xavier_uid = 23;	
+SET @yavonne_uid = 24;	
+SET @zoey_uid = 25;	
+SET @smoker_uid = 26;	
+
+INSERT INTO auth_scheme_data	
+    (auth_scheme, user_key, user_id, encrypted_password)	
+VALUES	
+      ('local', 'adefaultuser@example.com', @alice_uid,     @defaultPassword)	
+    , ('local', 'bsnooper@example.com',     @bob_uid,       @defaultPassword)	
+    , ('local', 'Carl',                     @carl_uid,      @defaultPassword)	
+    , ('local', 'Debbie',                   @debbie_uid,    @defaultPassword)	
+    , ('local', 'Edith',                    @edith_uid,     @defaultPassword)	
+    , ('local', 'Fred',                     @fred_uid,      @defaultPassword)	
+    , ('local', 'Ginna',                    @ginna_uid,     @defaultPassword)	
+    , ('local', 'Hazel',                    @hazel_uid,     @defaultPassword)	
+    , ('local', 'Ivy',                      @ivy_uid,       @defaultPassword)	
+    , ('local', 'Justin',                   @justin_uid,    @defaultPassword)	
+    , ('local', 'Kevin',                    @kevin_uid,     @defaultPassword)	
+    , ('local', 'Liz',                      @liz_uid,       @defaultPassword)	
+    , ('local', 'Martin',                   @martin_uid,    @defaultPassword)	
+    , ('local', 'Nick',                     @nick_uid,      @defaultPassword)	
+    , ('local', 'Ophelia',                  @ophelia_uid,   @defaultPassword)	
+    , ('local', 'Paul',                     @paul_uid,      @defaultPassword)	
+    , ('local', 'Quinton',                  @quinton_uid,   @defaultPassword)	
+    , ('local', 'Rachel',                   @rachel_uid,    @defaultPassword)	
+    , ('local', 'Tess',                     @tess_uid,      @defaultPassword)	
+    , ('local', 'Ursula',                   @ursula_uid,    @defaultPassword)	
+    , ('local', 'Vera',                     @vera_uid,      @defaultPassword)	
+    , ('local', 'Winston',                  @winston_uid,   @defaultPassword)	
+    , ('local', 'Xavier',                   @xavier_uid,    @defaultPassword)	
+    , ('local', 'Yavonne',                  @yavonne_uid,   @defaultPassword)	
+    , ('local', 'Zoey',                     @zoey_uid,      @defaultPassword)	
+    ;	
+
+INSERT INTO	
+    operations (`slug`, `name`, `description`, active, `status`)	
+VALUES	
+      ('alice-op',     'AliceOp',      'An operation for Alice',  1, 0)	
+    , ('bob-op',       'BobOp',        'An operation for Bob',    1, 0)	
+    , ('co-op',        'Co-Op',        'A Cooperative Operation', 1, 0)	
+    , ('no-op',        'No-Op',        'An Orphaned Operation',   1, 0)	
+    , ('big-op',       'BigOp',        'An operation with lots of users', 1, 0)	
+    ;	
+
+SET @alice_op_id = 1;	
+SET @bob_op_id = 2;	
+SET @co_op_id = 3;	
+SET @no_op_id = 4;	
+SET @big_op_id = 5;	
+
+INSERT INTO user_operation_permissions	
+    (`user_id`, `operation_id`, `role`)	
+VALUES	
+      (@alice_uid, @alice_op_id, 'admin')	
+    , (@bob_uid,   @bob_op_id,   'admin')	
+    , (@alice_uid, @co_op_id,    'admin')	
+    , (@bob_uid,   @co_op_id,    'admin')	
+
+    , (@alice_uid,   @big_op_id, 'admin')	
+    , (@carl_uid,    @big_op_id, 'read')	
+    , (@debbie_uid,  @big_op_id, 'write')	
+    , (@edith_uid,   @big_op_id, 'read')	
+    , (@fred_uid,    @big_op_id, 'write')	
+    , (@ginna_uid,   @big_op_id, 'read')	
+    , (@hazel_uid,   @big_op_id, 'read')	
+    , (@ivy_uid,     @big_op_id, 'write')	
+    , (@justin_uid,  @big_op_id, 'read')	
+    , (@kevin_uid,   @big_op_id, 'write')	
+    , (@liz_uid,     @big_op_id, 'read')	
+    , (@martin_uid,  @big_op_id, 'read')	
+    , (@nick_uid,    @big_op_id, 'read')	
+    , (@ophelia_uid, @big_op_id, 'write')	
+    , (@paul_uid,    @big_op_id, 'read')	
+    , (@quinton_uid, @big_op_id, 'write')	
+    , (@rachel_uid,  @big_op_id, 'read')	
+    , (@tess_uid,    @big_op_id, 'write')	
+    , (@ursula_uid,  @big_op_id, 'write')	
+    , (@vera_uid,    @big_op_id, 'read')	
+    , (@winston_uid, @big_op_id, 'write')	
+    , (@xavier_uid,  @big_op_id, 'read')	
+    , (@yavonne_uid, @big_op_id, 'write')	
+    , (@zoey_uid,    @big_op_id, 'read')	
+    ;	
+
+INSERT INTO tags	
+    (name, color_name, operation_id)	
+VALUES	
+      ('Europa', 'red',    @alice_op_id)	
+    , ('Titan',  'orange', @alice_op_id)	
+    , ('Io',     'yellow', @alice_op_id)	
+    , ('Ceres',  'green',  @alice_op_id)	
+    , ('Triton', 'blue',   @alice_op_id)	
+
+    , ('Doc',     'red',    @bob_op_id)	
+    , ('Grumpy',  'orange', @bob_op_id)	
+    , ('Happy',   'yellow', @bob_op_id)	
+    , ('Sleepy',  'green',  @bob_op_id)	
+    , ('Bashful', 'blue',   @bob_op_id)	
+    , ('Sneezy',  'indigo', @bob_op_id)	
+    , ('Dopey',   'violet', @bob_op_id)	
+
+    , ('application',  'lightRed',    @co_op_id)	
+    , ('presentation', 'lightOrange', @co_op_id)	
+    , ('session',      'lightYellow', @co_op_id)	
+    , ('transport',    'lightGreen',  @co_op_id)	
+    , ('network',      'lightBlue',   @co_op_id)	
+    , ('data link',    'lightIndigo', @co_op_id)	
+    , ('physical',     'lightViolet', @co_op_id)	
+    ;	
+
+-- Alice op tags	
+SET @tag_moon_1_id = 1;	
+SET @tag_moon_2_id = 2;	
+SET @tag_moon_3_id = 3;	
+SET @tag_moon_4_id = 4;	
+SET @tag_moon_5_id = 5;	
+
+-- Bob op tags	
+SET @tag_dwarf_1_id = 6;	
+SET @tag_dwarf_2_id = 7;	
+SET @tag_dwarf_3_id = 8;	
+SET @tag_dwarf_4_id = 9;	
+SET @tag_dwarf_5_id = 10;	
+SET @tag_dwarf_6_id = 11;	
+SET @tag_dwarf_7_id = 12;	
+
+-- Co op tags	
+SET @tag_osi_1_id = 13;	
+SET @tag_osi_2_id = 14;	
+SET @tag_osi_3_id = 15;	
+SET @tag_osi_4_id = 16;	
+SET @tag_osi_5_id = 17;	
+SET @tag_osi_6_id = 18;	
+SET @tag_osi_7_id = 19;	
+
+--                      0 1 2 3  4 5  6 7  8 9  A B C D E F	
+SET @a_op_evi_uuid_1 = 'a10E0000-0000-4000-a000-000000000000';	
+SET @a_op_evi_uuid_2 = 'a20E0000-0000-4000-a000-000000000000';	
+SET @a_op_evi_uuid_3 = 'a30E0000-c0de-4000-a000-000000000000';	
+
+SET @b_op_evi_uuid_1 = 'b10E0000-0000-4000-b000-000000000000';	
+SET @b_op_evi_uuid_2 = 'b20E0000-0000-4000-b000-000000000000';	
+SET @b_op_evi_uuid_3 = 'b30E0000-c0de-4000-b000-000000000000';	
+
+SET @c_op_evi_uuid_1 = 'c10E0000-0000-4000-8000-000000000000';	
+SET @c_op_evi_uuid_2 = 'c20E0000-0000-4000-8000-000000000000';	
+SET @c_op_evi_uuid_3 = 'c30E0000-c0de-4000-8000-000000000000';	
+
+
+INSERT INTO evidence	
+    (uuid, operation_id, operator_id, content_type, full_image_key, thumb_image_key, occurred_at, `description`)	
+VALUES	
+      (@a_op_evi_uuid_1, @alice_op_id, @alice_uid, 'image',     'seed_movie_full',    'seed_movie_thumb',    now(), CONCAT_WS(CHAR(10 using utf8), '# Movie Reel', '', 'Cinema''s favorite feature. Action. Excitement. Comedy.', 'Reviews:', '', '* A loud, long and pointless spectacle.', '* Schumacher''s storytelling is limp, and the characters lack energy.', '', '[Click here](https://www.rottentomatoes.com/m/1077027_batman_and_robin) for more info' ))	
+    , (@a_op_evi_uuid_2, @alice_op_id, @alice_uid, 'image',     'seed_popcorn_full',  'seed_popcorn_thumb',  now(), 'Popcorn Box')	
+    , (@a_op_evi_uuid_3, @alice_op_id, @alice_uid, 'codeblock', 'seed_go_aoc201614',  'seed_go_aoc201614',   now(), 'Go AOC 2016 Day 14 (https://adventofcode.com/2016/day/14)')	
+
+    , (@b_op_evi_uuid_1, @bob_op_id,   @bob_uid,   'image',     'seed_magazine_full', 'seed_magazine_thumb', now(), 'Magazine')	
+    , (@b_op_evi_uuid_2, @bob_op_id,   @bob_uid,   'image',     'seed_chicken_full',  'seed_chicken_thumb',  now(), 'Chickens with a Frisbee')	
+    , (@b_op_evi_uuid_3, @bob_op_id,   @bob_uid,   'codeblock', 'seed_py_aoc201717',  'seed_py_aoc201717',   now(), 'Python AOC 2017 Day 17 (https://adventofcode.com/2017/day/17)')	
+
+    , (@c_op_evi_uuid_1, @co_op_id,    @alice_uid, 'image',     'seed_pocky_full',    'seed_pocky_thumb',    now(), 'A miko holding a bunch of ofudas')	
+    , (@c_op_evi_uuid_2, @co_op_id,    @bob_uid,   'image',     'seed_rocky_full',    'seed_rocky_thumb',    now(), 'A raccoon juggling some leaves')	
+    , (@c_op_evi_uuid_3, @co_op_id,    @bob_uid,   'codeblock', 'seed_rs_aoc201501',  'seed_rs_aoc201501',   now(), 'Rust AOC 2015 Day 1 (https://adventofcode.com/2015/day/1)')	
+
+    ;	
+
+SET @a_op_evi_1 = 1;	
+SET @a_op_evi_2 = 2;	
+SET @a_op_evi_3 = 3;	
+SET @b_op_evi_1 = 4;	
+SET @b_op_evi_2 = 5;	
+SET @b_op_evi_3 = 6;	
+SET @c_op_evi_1 = 7;	
+SET @c_op_evi_2 = 8;	
+SET @c_op_evi_3 = 9;	
+
+SET @a_op_evt_uuid_1 = 'a10F0000-0000-4000-a000-000000000000';	
+SET @a_op_evt_uuid_2 = 'a20F0000-0000-4000-a000-000000000000';	
+
+SET @b_op_evt_uuid_1 = 'b10F0000-0000-4000-b000-000000000000';	
+SET @b_op_evt_uuid_2 = 'b20F0000-0000-4000-b000-000000000000';	
+
+SET @c_op_evt_uuid_1 = 'c10F0000-0000-4000-8000-000000000000';	
+SET @c_op_evt_uuid_2 = 'c20F0000-0000-4000-8000-000000000000';	
+
+INSERT INTO findings	
+    (`uuid`, `operation_id`, `category`, `title`, `description`, `ready_to_report`, `ticket_link`)	
+VALUES	
+      (@a_op_evt_uuid_1, @alice_op_id, 'OPSEC', 'Main Event',                'body', true,  'http://google.com') -- 1	
+    , (@a_op_evt_uuid_2, @alice_op_id, 'OPSEC', 'Side Show left',            'body', true,  null) -- 2	
+    , (@b_op_evt_uuid_1, @bob_op_id,   'OPSEC', 'Bob Sees an Issue',         'body', false, null) -- 3	
+    , (@b_op_evt_uuid_2, @bob_op_id,   'OPSEC', 'Bob Suspects Fowl Play',    'body', false, null) -- 4	
+    , (@c_op_evt_uuid_1, @co_op_id,    'OPSEC', 'I get Pocky',               'body', false, null) -- 5	
+    , (@c_op_evt_uuid_2, @co_op_id,    'OPSEC', 'Bob gets stuck with Rocky', 'body', false, null) -- 6	
+    ;	
+
+SET @a_op_evt_1 = 1;	
+SET @a_op_evt_2 = 2;	
+SET @b_op_evt_1 = 3;	
+SET @b_op_evt_2 = 4;	
+SET @c_op_evt_1 = 5;	
+SET @c_op_evt_2 = 6;	
+
+INSERT INTO evidence_finding_map 	
+    (evidence_id, finding_id)	
+VALUES	
+      (@a_op_evi_1, @a_op_evt_1)	
+    , (@a_op_evi_2, @a_op_evt_2)	
+    , (@a_op_evi_3, @a_op_evt_2)	
+    , (@b_op_evi_1, @b_op_evt_1)	
+    , (@b_op_evi_2, @b_op_evt_2)	
+    , (@b_op_evi_3, @b_op_evt_2)	
+    , (@c_op_evi_1, @c_op_evt_1)	
+    , (@c_op_evi_2, @c_op_evt_2)	
+    , (@c_op_evi_3, @c_op_evt_2)	
+    ;	
+
+INSERT INTO tag_evidence_map	
+    (tag_id, evidence_id)	
+VALUES	
+      (@tag_moon_1_id, @a_op_evi_1)	
+    , (@tag_moon_2_id, @a_op_evi_1)	
+    , (@tag_moon_3_id, @a_op_evi_2)	
+    , (@tag_moon_2_id, @a_op_evi_2)	
+    , (@tag_moon_4_id, @a_op_evi_3)	
+    , (@tag_moon_5_id, @a_op_evi_3)	
+
+    , (@tag_dwarf_4_id, @b_op_evi_1)	
+    , (@tag_dwarf_5_id, @b_op_evi_1)	
+    , (@tag_dwarf_1_id, @b_op_evi_2)	
+    , (@tag_dwarf_4_id, @b_op_evi_2)	
+    , (@tag_dwarf_7_id, @b_op_evi_3)	
+    , (@tag_dwarf_6_id, @b_op_evi_3)	
+
+    , (@tag_osi_6_id, @c_op_evi_1)	
+    , (@tag_osi_5_id, @c_op_evi_1)	
+    , (@tag_osi_7_id, @c_op_evi_2)	
+    , (@tag_osi_1_id, @c_op_evi_2)	
+    , (@tag_osi_3_id, @c_op_evi_3)	
+    , (@tag_osi_2_id, @c_op_evi_3)	
+    ;	
+
+SET @api_key = 'DAYPFGHnm1Pqes-l0Fm76_y1';	
+SET @secret_key = 0x1EA9AE5B294BCE747EB6A4A8B5900E73EC38EDBB9215A28A4C9A33A5711892E3418AE449830DCD7893AE54FEA46D00509A2613A9801A88829B70ED41C5C1F9D9;	
+-- secret_key: HqmuWylLznR+tqSotZAOc+w47buSFaKKTJozpXEYkuNBiuRJgw3NeJOuVP6kbQBQmiYTqYAaiIKbcO1BxcH52Q==	
+
+INSERT INTO api_keys	
+    (user_id, access_key, secret_key)	
+VALUES	
+      (@smoker_uid, @api_key, @secret_key)	
+    ;

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -53,6 +53,7 @@ services:
     volumes:
       - ./backend/schema.sql:/docker-entrypoint-initdb.d/schema.sql
       - ./dev_seed_data/z01_seed_data.sql:/docker-entrypoint-initdb.d/z01_seed_data.sql
+      - ./dev_seed_data/z02_gantt_operation.sql:/docker-entrypoint-initdb.d/z02_gantt_operation.sql
     environment:
       - MYSQL_DATABASE=dev-db
       - MYSQL_ROOT_PASSWORD=dev-root-password

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,8 +16,18 @@ server {
       proxy_pass http://ashirt-private-service:8000;
     }
 
+    location /assets {
+      root     /usr/share/nginx/html;
+      try_files $uri $uri/;
+    }
+
     location / {
-        root   /usr/share/nginx/html;
-        try_files $uri $uri/ /index.html;
+      root   /usr/share/nginx/html;
+      try_files $uri /index.html;
+      add_header Last-Modified $date_gmt;
+      add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+      if_modified_since off;
+      expires off;
+      etag off;
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,6 +107,12 @@
         "@types/testing-library__react-hooks": "^3.0.0"
       }
     },
+    "@types/anymatch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
@@ -139,6 +145,12 @@
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.3.tgz",
       "integrity": "sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==",
+      "dev": true
+    },
+    "@types/html-minifier-terser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
+      "integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA==",
       "dev": true
     },
     "@types/json-schema": {
@@ -258,6 +270,18 @@
       "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
     },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+      "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
+      "dev": true
+    },
     "@types/testing-library__react-hooks": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz",
@@ -266,6 +290,48 @@
       "requires": {
         "@types/react": "*",
         "@types/react-test-renderer": "*"
+      }
+    },
+    "@types/uglify-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.22",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+      "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
+      "dev": true,
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
+      "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/eslint-plugin": {
@@ -1134,6 +1200,12 @@
         "multicast-dns-service-types": "^1.1.0"
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1322,6 +1394,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camel-case": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+      "dev": true,
+      "requires": {
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1533,6 +1615,15 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
+    "clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      }
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -1871,6 +1962,42 @@
         "css": "^2.0.0"
       }
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+          "dev": true
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        }
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2108,6 +2235,15 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "dev": true,
+      "requires": {
+        "utila": "~0.4"
+      }
+    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -2144,6 +2280,16 @@
         "dom-serializer": "^0.2.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "duplexify": {
@@ -4012,6 +4158,29 @@
       "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
       "dev": true
     },
+    "html-minifier-terser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
+        "he": "^1.2.0",
+        "param-case": "^3.0.3",
+        "relateurl": "^0.2.7",
+        "terser": "^4.6.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
+      }
+    },
     "html-to-react": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
@@ -4021,6 +4190,32 @@
         "htmlparser2": "^4.0",
         "lodash.camelcase": "^4.3.0",
         "ramda": "^0.26"
+      }
+    },
+    "html-webpack-harddisk-plugin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-1.0.2.tgz",
+      "integrity": "sha512-s0F0qAxug9fgztJyWWa8cUlVvgbAD/+J9Dhg22REU637DV9RhrKt0EsFBOXkRuSuwSeYLUtyLcQYpARPBZe51g==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "html-webpack-plugin": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.4.1.tgz",
+      "integrity": "sha512-nEtdEIsIGXdXGG7MjTTZlmhqhpHU9pJFc1OYxcP36c5/ZKP6b0BJMww2QTvJGQYA9aMxUnjDujpZdYcVOXiBCQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier-terser": "^5.0.0",
+        "@types/tapable": "^1.0.5",
+        "@types/webpack": "^4.41.8",
+        "html-minifier-terser": "^5.0.1",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.15",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.3",
+        "util.promisify": "1.0.0"
       }
     },
     "htmlparser2": {
@@ -4906,6 +5101,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5419,6 +5623,16 @@
         }
       }
     },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -5507,6 +5721,15 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0"
       }
     },
     "object-assign": {
@@ -5952,6 +6175,16 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "param-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5999,6 +6232,16 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
+    },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -6217,6 +6460,16 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
+    },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
+      }
     },
     "process": {
       "version": "0.11.10",
@@ -6756,6 +7009,12 @@
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
     "remark-parse": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
@@ -6783,6 +7042,92 @@
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+      "dev": true,
+      "requires": {
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+          "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.1",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -8614,6 +8959,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utils-merge": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,8 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.1",
     "file-loader": "^4.3.0",
+    "html-webpack-harddisk-plugin": "^1.0.2",
+    "html-webpack-plugin": "^4.4.1",
     "mini-css-extract-plugin": "^0.8.2",
     "mocha": "^6.2.3",
     "react-test-renderer": "^16.13.1",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,4 +1,6 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const HtmlWebpackHarddiskPlugin = require("html-webpack-harddisk-plugin");
 const path = require('path')
 
 module.exports = (env, argv) => ({
@@ -6,7 +8,7 @@ module.exports = (env, argv) => ({
 
   output: {
     publicPath: '/assets/',
-    filename: 'main.js',
+    filename: 'main-[hash].js',
     chunkFilename: '[chunkhash].js',
   },
 
@@ -39,8 +41,15 @@ module.exports = (env, argv) => ({
   },
 
   plugins: [
+    new HtmlWebpackPlugin({
+      title: "ASHIRT",
+      alwaysWriteToDisk: true,
+    }),
+    new HtmlWebpackHarddiskPlugin({
+      outputPath: path.resolve(__dirname, 'public')
+    }),
     new MiniCssExtractPlugin({
-      filename: 'main.css',
+      filename: 'main-[hash].css',
       chunkFilename: '[chunkhash].css',
     }),
   ],


### PR DESCRIPTION
This PR makes a change that should hopefully make cache busting consistently work.

The core of this change is by dynamically generating the index.html file with dynamically named main.js and main.css files. This should prevent errant loading of old assets, as each should have a new, unique name every time the service is built and deployed. 
This is accomplished by adding two libraries that interact with webpack. The first, `html-webpack-plugin`, generates the dynamic index.html file and stores this in memory. The second, `html-webpack-harddisk-plugin` allows us to write this dynamic html file to disk at the specified location.
In addition, this also updates the `nginx.conf` file to attempt to do as much as possible to prevent the index.html file from being cached itself. All other files (located under `/assets/`) should have normal caching rules applied to them.

In addition, a handful of small, but related changes, have been made to make testing easier. The first is restoring (And adding) the old seed data, to allow the production docker-compose file to provide a pre-seeded database. This should be amended in the future, but is far outside the scope of this PR, hence the easy solution of restoring the old content (note: this only restores the data, not the content). The second is simply an easy way to start up the production docker-compose containers via the makefile.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.