### PR TITLE
Try to improve description rendering

### DIFF
--- a/frontend/src/components/markdown_renderer/index.tsx
+++ b/frontend/src/components/markdown_renderer/index.tsx
@@ -2,19 +2,14 @@
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
-import {useAsyncComponent} from 'src/helpers'
-const importRendererAsync = () => import('./sync_renderer').then(module => module.default)
 
-// Renders a markdown string passed to `children` after asynchronously downloading the markdown renderer javascript bundle
+import SyncMarkdownRenderer from './sync_renderer'
+
 export default (props: {
   className?: string,
   children: string,
-}) => {
-  const AsyncMarkdownRenderer = useAsyncComponent(importRendererAsync)
-
-  return (
-    <div className={props.className}>
-      <AsyncMarkdownRenderer children={props.children} />
-    </div>
-  )
-}
+}) => (
+  <div className={props.className}>
+    <SyncMarkdownRenderer children={props.children} />
+  </div>
+)


### PR DESCRIPTION
This PR attempts to further speed up description rendering on the timeline. 

The current issue faced is that rendering markdown is slow due to a bottleneck with asset loading. Descriptions are rendered in markdown and the markdown renderer is dynamically loaded. This means that when the other dynamic elements come in, the code needs to react to both downloading those assets, as well as downloading the markdown rendering code.

This change simply preloads the markdown renderer, which should show all descriptions as soon as the timeline component loads, as well as the request to get evidence completes. There should no longer be a situation where the loading animation plays where the description is supposed to be.

This affects all areas where the markdown renderer is used (evidence descriptions, and finding descriptions). 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.