### PR TITLE
Add API check connection endpoint

### DIFF
--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -140,3 +140,7 @@ type TagByEvidenceDate struct {
 	Tag
 	UsageDates []time.Time `json:"usages"`
 }
+
+type CheckConnection struct {
+	Ok bool `json:"ok"`
+}

--- a/backend/dtos/gentypes/generate_typescript_types.go
+++ b/backend/dtos/gentypes/generate_typescript_types.go
@@ -34,6 +34,7 @@ func main() {
 	gen(dtos.TagPair{})
 	gen(dtos.TagDifference{})
 	gen(dtos.TagByEvidenceDate{})
+	gen(dtos.CheckConnection{})
 
 	// Since this file only contains typescript types, webpack doesn't pick up the
 	// changes unless there is some actual executable javascript referenced from

--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/contentstore"
 	"github.com/theparanoids/ashirt-server/backend/database"
+	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/logging"
 	"github.com/theparanoids/ashirt-server/backend/models"
 	"github.com/theparanoids/ashirt-server/backend/server/middleware"
@@ -52,10 +53,7 @@ func bindAPIRoutes(r *mux.Router, db *database.Connection, contentStore contents
 	}))
 
 	route(r, "GET", "/api/checkconnection", jsonHandler(func(r *http.Request) (interface{}, error) {
-		reply := struct {
-			Connected bool `json:"ashirtConnected"`
-		}{true}
-		return reply, nil
+		return dtos.CheckConnection{Ok: true}, nil
 	}))
 
 	route(r, "GET", "/api/operations/{operation_id}", jsonHandler(func(r *http.Request) (interface{}, error) {

--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -51,6 +51,13 @@ func bindAPIRoutes(r *mux.Router, db *database.Connection, contentStore contents
 		return services.ListOperations(r.Context(), db)
 	}))
 
+	route(r, "GET", "/api/checkconnection", jsonHandler(func(r *http.Request) (interface{}, error) {
+		reply := struct {
+			Connected bool `json:"ashirtConnected"`
+		}{true}
+		return reply, nil
+	}))
+
 	route(r, "GET", "/api/operations/{operation_id}", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		operationID := dr.FromURL("operation_id").Required().AsInt64()


### PR DESCRIPTION
This PR adds a simple connection check endpoint to the api server. This is done to provide a more robust way to ensure that an api is talking to an actual ASHIRT server. 

In psuedo code, the recommended solution for verifying the server is:

```python
def check_connection(host: string, accessKey: string, secretKey: byte[]) -> string:
  resp = network.GET(apiHome() + "/checkconnection", {
     "Authorization": accessKey + ":" +secretKey,
     "Date": get_rfc_1123_date()
  })
  if resp.status == HTTPStatus.OK:
    parsedData = json.Parse(resp.data)
    if parsedData.parsedSuccessfully() and parsedData.ashirtConnected == true:
      return "Connected"
    else:
      return "Incorrect or outdated server"
  elif resp.status == HTTPStatus.Unauthorized:  # http code: 401 
    return "Access or Secret Key mismatch"
  elif resp.status == HTTPStatus.NotFound:  # http code: 404
    return "Server not present at address"  # Check host string
  else:
    return "Unexpected error: " + resp.status  
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.