### PR TITLE
Restrict evidence fit/full toggle to image evidence only

### DIFF
--- a/frontend/src/components/lightbox/index.tsx
+++ b/frontend/src/components/lightbox/index.tsx
@@ -9,7 +9,7 @@ const cx = classnames.bind(require('./stylesheet'))
 export default (props: {
   children: React.ReactNode,
   isOpen: boolean,
-  showToggle?: boolean
+  canUseFitToggle?: boolean
   onRequestClose: () => void,
 }) => {
   const [exists, setExists] = React.useState<boolean>(false)
@@ -38,10 +38,15 @@ export default (props: {
   })
 
   if (!exists) return null
+
+  const toggleClasses = props.canUseFitToggle
+    ? [full ? "full" : "fit", props.canUseFitToggle ? 'can-fit': '']
+    : []
+
   return (
     createPortal((
       <div className={cx('root', animating ? 'animating' : 'open')} onClick={props.onRequestClose}>
-        <div className={cx('content', full ? "full" : "fit")} onClick={e => e.stopPropagation()}>
+        <div className={cx('content', ...toggleClasses)} onClick={e => e.stopPropagation()}>
           {props.children}
         </div>
       </div>

--- a/frontend/src/components/lightbox/stylesheet.styl
+++ b/frontend/src/components/lightbox/stylesheet.styl
@@ -33,13 +33,13 @@
 .open
   opacity: 1
 
-.fit
+.fit.can-fit
   img
-    display: block
-    width: 95vw
-    height: 95vh
-    object-fit: contain
+      display: block
+      width: 95vw
+      height: 95vh
+      object-fit: contain
 
-.full
+.full.can-fit
   img
     display: block

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -222,5 +222,5 @@ export const KeyboardShortcuts = [
   { keys: ["Enter"], description: "Open evidence large view" },
   { keys: ["Escape"], description: "Close evidence large view" },
   { keys: [" "], description: "Toggle evidence large view" },
-  { keys: ["z", "Z"], description: "Toggle Best Fit vs standard view" },
+  { keys: ["z", "Z"], description: "Toggle Best Fit vs Standard views" },
 ]

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -99,7 +99,7 @@ export default (props: {
         shortcuts={KeyboardShortcuts}
       />
     </div>
-    <Lightbox showToggle={activeEvidence.contentType == "image"}
+    <Lightbox canUseFitToggle={activeEvidence.contentType == "image"}
       isOpen={quicklookVisible} onRequestClose={() => setQuicklookVisible(false)}>
       <div ref={lightboxRef}>
         <EvidencePreview


### PR DESCRIPTION
This PR revises the evidence full-screen view to only allow toggling between fit- and full-evidence views when the evidence is an image type. This prevents an issue where evidence types that contain an image could grow to exceptionally large views.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.