### PR TITLE
Fix recovery auth

### DIFF
--- a/backend/authschemes/auth_bridge.go
+++ b/backend/authschemes/auth_bridge.go
@@ -210,7 +210,10 @@ func (ah AShirtAuthBridge) OneTimeVerification(ctx context.Context, userKey stri
 
 		tx.Delete(sq.Delete("auth_scheme_data").Where(sq.Eq{"user_key": userKey}))
 	})
-	return userID, backend.WrapError("Unable to validate one-time verification", err)
+	if err != nil {
+		return 0, backend.WrapError("Unable to validate one-time verification", err)
+	}
+	return userID, nil
 }
 
 // GetDatabase provides raw access to the database. In general, this should not be used by authschemes,

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -44,6 +44,9 @@ export default () => {
       <Redirect exact from="/login" to="/operations" />
       <Redirect exact from="/" to="/operations" />
 
+      {/* AuthError routes that an admin might reach if testing */}
+      <Route exact path="/autherror/recoveryfailed" render={makeErrorDisplay("Access Error", "This url only works for users that are not logged in. ", true)} />
+
       <Route exact path="/operations" component={AsyncOperationList} />
 
       {/* Operation edit */}


### PR DESCRIPTION
This PR corrects an issue where every One-Time Auth would fail, due to how error wrapping works. This also introduces a unique error page for admins that create a recovery code and try to use it while logged in (Technically this happens for any logged in user, but in practice this should only happen for admins that try to verify recovery urls)

Addresses PR #75 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.