### PR TITLE
remove file-loader esModule default

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -36,7 +36,14 @@ module.exports = (env, argv) => ({
       ],
     }, {
       test: /\.(svg|png|ttf|woff)/,
-      use: 'file-loader',
+      use: [
+        {
+          loader: 'file-loader',
+          options: {
+            esModule: false
+          }
+        }
+      ]
     }],
   },
 


### PR DESCRIPTION
This PR uses the previous file-loader method for requiring assets (rather than the new default, by esModule) . This will restore the missing icons introduced after the file-loader upgrade to 6.1.0 PR was merged.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.