### PR TITLE
Change dependabot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Set the dependabot interval for npm and go to weekly due to the
frequency of changes for specific many of the packages. These typically
are small point releases many of which are unimportant. This seems to be
handled differently for security related issues. We may choose to push
this out to monthly even depending on how loud this still is.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.