### PR TITLE
remove no-delete-last-auth check

### DIFF
--- a/frontend/src/pages/account_settings/auth_methods/index.tsx
+++ b/frontend/src/pages/account_settings/auth_methods/index.tsx
@@ -70,7 +70,6 @@ const TableRow = (props: {
   const canDeleteAuth = () => {
     switch (true) {
       case (!userScheme): return { disabled: true, title: "Auth scheme has not been linked" }
-      case (props.authInfo.length == 1): return { disabled: true, title: "Cannot delete only remaining authentication method" }
       default: return {}
     }
   }

--- a/frontend/src/pages/account_settings/auth_methods/index.tsx
+++ b/frontend/src/pages/account_settings/auth_methods/index.tsx
@@ -43,6 +43,7 @@ export default (props: {
               supportedScheme={scheme}
               authInfo={props.profile.authSchemes}
               removeAuth={() => setRemovingAuth(scheme.schemeCode)}
+              requestReload={props.requestReload}
             />
           ))}
         </Table>
@@ -62,6 +63,7 @@ const TableRow = (props: {
   authInfo: Array<AuthenticationInfo>,
   removeAuth: () => void,
   allowLinking: boolean,
+  requestReload?: () => void,
 }) => {
   const [linking, setLinking] = React.useState<boolean>(false)
   const Linker = useAuthFrontendComponent(props.supportedScheme.schemeCode, 'Linker')
@@ -95,7 +97,10 @@ const TableRow = (props: {
       </td>
       {linking && (
         <Modal onRequestClose={() => setLinking(false)} title={"Link Account"}>
-          <Linker onSuccess={() => setLinking(false)} />
+          <Linker onSuccess={() => {
+            setLinking(false)
+            props.requestReload && props.requestReload()
+          }} />
         </Modal>
       )}
     </tr>


### PR DESCRIPTION
This PR removes the (front end) safeguard that prevents a user from deleting their last authentication method. Since there is already a prompt asking for confirmation, no additional warnings have been added.

No safeguard is present on the back end, so no change is necessary there.  

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.