### PR TITLE
Show friendly error message when multifactor auth status is unavailable

### DIFF
--- a/frontend/src/authschemes/local/totp/index.tsx
+++ b/frontend/src/authschemes/local/totp/index.tsx
@@ -17,7 +17,12 @@ const cx = classnames.bind(require('./stylesheet'))
 
 export default (props: {
 }) => {
-  const wiredTotpIsEnabled = useWiredData(totpIsEnabled)
+  const wiredTotpIsEnabled = useWiredData(totpIsEnabled, (err: Error)=>(
+    <div className={cx('plain-error')}>
+      Multifactor Authentication is not available for this account. Please ensure you have linked
+      ASHIRT local authentication.
+    </div>
+  ))
 
   return (
     <SettingsSection title="Multi-Factor Authentication" className={cx('root')}>

--- a/frontend/src/authschemes/local/totp/stylesheet.styl
+++ b/frontend/src/authschemes/local/totp/stylesheet.styl
@@ -18,3 +18,6 @@
   margin: 10px auto
   border-radius: 5px
   border: 1px solid $darker-background
+
+.plain-error
+  font-style: italic


### PR DESCRIPTION
This PR adds a simple error message when a user 404s (fails an account lookup for local auth) when checking multiifactor authentication status.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.