### PR TITLE
Remove unsupported authentication schemes from read user result

### DIFF
--- a/backend/server/web.go
+++ b/backend/server/web.go
@@ -118,7 +118,7 @@ func bindWebRoutes(r *mux.Router, db *database.Connection, contentStore contents
 		if dr.Error != nil {
 			return nil, dr.Error
 		}
-		return services.ReadUser(r.Context(), db, slug)
+		return services.ReadUser(r.Context(), db, slug, supportedAuthSchemes)
 	}))
 
 	route(r, "GET", "/users", jsonHandler(func(r *http.Request) (interface{}, error) {

--- a/backend/services/read_user.go
+++ b/backend/services/read_user.go
@@ -28,7 +28,7 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string, sup
 	}
 
 	supportedAuthCodes := make([]string, len(*supportedAuthSchemes))
-	for i, scheme := range (*supportedAuthSchemes) {
+	for i, scheme := range *supportedAuthSchemes {
 		supportedAuthCodes[i] = scheme.SchemeCode
 	}
 
@@ -42,7 +42,7 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string, sup
 		db.Select(&authSchemes, sq.Select("user_key", "auth_scheme", "last_login").
 			From("auth_scheme_data").
 			Where(sq.Eq{
-				"user_id": userID, 
+				"user_id":     userID,
 				"auth_scheme": supportedAuthCodes,
 			}))
 	})

--- a/backend/services/read_user.go
+++ b/backend/services/read_user.go
@@ -17,7 +17,7 @@ import (
 
 // ReadUser retrieves a detailed view of a user. This is separate from the data retriving by listing
 // users, or reading another user's profile (when not an admin)
-func ReadUser(ctx context.Context, db *database.Connection, userSlug string) (*dtos.UserOwnView, error) {
+func ReadUser(ctx context.Context, db *database.Connection, userSlug string, supportedAuthSchemes *[]dtos.SupportedAuthScheme) (*dtos.UserOwnView, error) {
 	userID, err := SelfOrSlugToUserID(ctx, db, userSlug)
 	if err != nil {
 		return nil, backend.WrapError("Unable to read user", backend.DatabaseErr(err))
@@ -25,6 +25,11 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string) (*d
 
 	if err := policy.Require(middleware.Policy(ctx), policy.CanReadDetailedUser{UserID: userID}); err != nil {
 		return nil, backend.WrapError("Unwilling to read user", backend.UnauthorizedReadErr(err))
+	}
+
+	supportedAuthCodes := make([]string, len(*supportedAuthSchemes))
+	for i, scheme := range (*supportedAuthSchemes) {
+		supportedAuthCodes[i] = scheme.SchemeCode
 	}
 
 	var user models.User
@@ -36,7 +41,10 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string) (*d
 
 		db.Select(&authSchemes, sq.Select("user_key", "auth_scheme", "last_login").
 			From("auth_scheme_data").
-			Where(sq.Eq{"user_id": userID}))
+			Where(sq.Eq{
+				"user_id": userID, 
+				"auth_scheme": supportedAuthCodes,
+			}))
 	})
 	if err != nil {
 		return nil, backend.WrapError("Cannot read user", backend.DatabaseErr(err))


### PR DESCRIPTION
This PR revises ReadUser on the backend to only return auth schemes that are currently supported. This would typically come into play when an administrator decided to remove an auth scheme after some use  had previously occurred. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.