### PR TITLE
Add ability for API users to create operations

### DIFF
--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -56,6 +56,19 @@ func bindAPIRoutes(r *mux.Router, db *database.Connection, contentStore contents
 		return dtos.CheckConnection{Ok: true}, nil
 	}))
 
+	route(r, "POST", "/api/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
+		dr := dissectJSONRequest(r)
+		i := services.CreateOperationInput{
+			Slug:    dr.FromBody("slug").Required().AsString(),
+			Name:    dr.FromBody("name").Required().AsString(),
+			OwnerID: middleware.UserID(r.Context()),
+		}
+		if dr.Error != nil {
+			return nil, dr.Error
+		}
+		return services.CreateOperation(r.Context(), db, i)
+	}))
+
 	route(r, "GET", "/api/operations/{operation_id}", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		operationID := dr.FromURL("operation_id").Required().AsInt64()

--- a/backend/services/create_operation.go
+++ b/backend/services/create_operation.go
@@ -38,7 +38,7 @@ func CreateOperation(ctx context.Context, db *database.Connection, i CreateOpera
 
 	cleanSlug := SanitizeOperationSlug(i.Slug)
 	if cleanSlug == "" {
-		return nil, backend.BadInputErr(errors.New("Unable t o create operation. Invalid operation slug"), "Slug must contain english letters or numbers")
+		return nil, backend.BadInputErr(errors.New("Unable to create operation. Invalid operation slug"), "Slug must contain english letters or numbers")
 	}
 
 	err := db.WithTx(ctx, func(tx *database.Transactable) {


### PR DESCRIPTION
This PR simply allows API users to create an operation. This route is identical to the web version.

Note that _all_ users can create operations, so long as they are logged in.

Note 2: A [companion PR](https://github.com/theparanoids/ashirt/pull/66) exists enabling this feature in ashirt, though it does not really matter which PR is merged first.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.