### PR TITLE
revise new op button to be perfectly centered

### DIFF
--- a/frontend/src/pages/operation_list/new_operation_button/index.tsx
+++ b/frontend/src/pages/operation_list/new_operation_button/index.tsx
@@ -12,7 +12,7 @@ export default (props: {
     className={cx('root')}
     onClick={props.onClick}
   >
-    <div>+</div>
+    <div className={cx('circle', 'plus')} />
     New Operation
   </button>
 )

--- a/frontend/src/pages/operation_list/new_operation_button/stylesheet.styl
+++ b/frontend/src/pages/operation_list/new_operation_button/stylesheet.styl
@@ -9,7 +9,8 @@
   color: $foreground
   cursor: pointer
 
-  div
+  .circle
+    position: relative
     background: $foreground
     width: 40px
     height: @width
@@ -22,3 +23,22 @@
   &:hover
     background: $lighter-background
     border-radius: 5px
+
+  // plus-inverse-size shrinks as the pixel size grows. max size is effective 9
+  $plus-inverse-size=13px
+  $plus-weight=2px
+  .plus
+    &:before, &:after
+      content: ""
+      position: absolute
+      top: 0
+      left: 0
+      right: 0
+      bottom: 0
+      background: $background
+    &:before
+      margin: $plus-inverse-size auto
+      width: $plus-weight
+    &:after
+      margin: auto $plus-inverse-size
+      height: $plus-weight

--- a/frontend/src/pages/operation_list/new_operation_button/stylesheet.styl
+++ b/frontend/src/pages/operation_list/new_operation_button/stylesheet.styl
@@ -25,7 +25,7 @@
     border-radius: 5px
 
   // plus-inverse-size shrinks as the pixel size grows. max size is effective 9
-  $plus-inverse-size=13px
+  $plus-inverse-size=14px
   $plus-weight=2px
   .plus
     &:before, &:after


### PR DESCRIPTION
This PR replaces the font-based plus icon with a css-based drawing.

New "New Operation" button:
![Screenshot from 2020-12-15 12-26-11](https://user-images.githubusercontent.com/10979605/102268895-bb371100-3ed0-11eb-8b5a-5d51f5452b0f.png)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.