### PR TITLE
Implement ordered results for timeline queries

### DIFF
--- a/backend/helpers/query_parser.go
+++ b/backend/helpers/query_parser.go
@@ -28,6 +28,7 @@ type TimelineFilters struct {
 	DateRange        *DateRange
 	WithEvidenceUUID string
 	Linked           *bool
+	SortAsc          bool
 }
 
 // ParseTimelineQuery parses a query a user may type into the search box on the timeline page
@@ -79,6 +80,16 @@ func ParseTimelineQuery(query string) (TimelineFilters, error) {
 				return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)
 			}
 			timelineFilters.Linked = &val
+		case "sort-direction":
+			if len(v) != 1 {
+				errReason := "Only one sorting flag can be specified"
+				return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)
+			}
+			direction := strings.ToLower(v[0])
+			if direction == "asc" || direction == "chronological" || direction == "ascending" {
+				timelineFilters.SortAsc = true
+			}
+
 		default:
 			errReason := fmt.Sprintf("Unknown filter key '%s'", k)
 			return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)

--- a/backend/helpers/query_parser.go
+++ b/backend/helpers/query_parser.go
@@ -80,7 +80,7 @@ func ParseTimelineQuery(query string) (TimelineFilters, error) {
 				return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)
 			}
 			timelineFilters.Linked = &val
-		case "sort-direction":
+		case "sort":
 			if len(v) != 1 {
 				errReason := "Only one sorting flag can be specified"
 				return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)

--- a/backend/helpers/query_parser_test.go
+++ b/backend/helpers/query_parser_test.go
@@ -61,6 +61,12 @@ func TestParseTimelineQuery(t *testing.T) {
 		Text:      []string{"Time", "range", "example"},
 		DateRange: &helpers.DateRange{time.Date(2019, 5, 1, 8, 0, 0, 0, time.UTC), time.Date(2019, 8, 5, 19, 30, 0, 0, time.UTC)},
 	})
+	testTimelineQueryCase(t, `uuid:00000000-1234-5678-ABCD-000000000000`, helpers.TimelineFilters{
+		UUID: "00000000-1234-5678-ABCD-000000000000",
+	})
+	testTimelineQueryCase(t, `with-evidence:00000000-1234-5678-ABCD-000000000000`, helpers.TimelineFilters{
+		WithEvidenceUUID: "00000000-1234-5678-ABCD-000000000000",
+	})
 
 	True := true
 	False := false
@@ -73,7 +79,30 @@ func TestParseTimelineQuery(t *testing.T) {
 	testTimelineQueryCase(t, `linked:all`, helpers.TimelineFilters{
 		Linked: nil,
 	})
+	testTimelineQueryCase(t, `sort-direction:asc`, helpers.TimelineFilters{
+		SortAsc: true,
+	})
+	testTimelineQueryCase(t, `sort-direction:chronological`, helpers.TimelineFilters{
+		SortAsc: true,
+	})
+	testTimelineQueryCase(t, `sort-direction:ascending`, helpers.TimelineFilters{
+		SortAsc: true,
+	})
 
+	testTimelineQueryCase(t, `sort-direction:desc`, helpers.TimelineFilters{
+		SortAsc: false,
+	})
+	testTimelineQueryCase(t, ``, helpers.TimelineFilters{
+		SortAsc: false,
+	})
+	
 	testTimelineQueryExpectErr(t, `invalid keys cause error invalid:value`)
-	testTimelineQueryExpectErr(t, `multiple operators cause error operator:alice operator:bob`)
+	testTimelineQueryExpectErr(t, `multiple operators       cause error operator:alice operator:bob`)
+	testTimelineQueryExpectErr(t, `multiple uuids           cause error uuid:ABC123 uuid:XYZ789`) // actual uuid doesn't currently matter
+	testTimelineQueryExpectErr(t, `multiple with_evidence   cause error with-evidence:ABC123 with-evidence:XYZ789`)
+	testTimelineQueryExpectErr(t, `multiple linked          cause error linked:all linked:true`)
+	testTimelineQueryExpectErr(t, `multiple sort_directions cause error sort-direction:desc sort-direction:asc`)
+	testTimelineQueryExpectErr(t, `unparsable bool/not all cause error linked:maybe`)
+	testTimelineQueryExpectErr(t, `unparsable date cause error range:2021-01-01,2021-02-31`)
+	testTimelineQueryExpectErr(t, `unparsable date cause error (alt) range:2021-01-01`)
 }

--- a/backend/helpers/query_parser_test.go
+++ b/backend/helpers/query_parser_test.go
@@ -79,17 +79,17 @@ func TestParseTimelineQuery(t *testing.T) {
 	testTimelineQueryCase(t, `linked:all`, helpers.TimelineFilters{
 		Linked: nil,
 	})
-	testTimelineQueryCase(t, `sort-direction:asc`, helpers.TimelineFilters{
+	testTimelineQueryCase(t, `sort:asc`, helpers.TimelineFilters{
 		SortAsc: true,
 	})
-	testTimelineQueryCase(t, `sort-direction:chronological`, helpers.TimelineFilters{
+	testTimelineQueryCase(t, `sort:chronological`, helpers.TimelineFilters{
 		SortAsc: true,
 	})
-	testTimelineQueryCase(t, `sort-direction:ascending`, helpers.TimelineFilters{
+	testTimelineQueryCase(t, `sort:ascending`, helpers.TimelineFilters{
 		SortAsc: true,
 	})
 
-	testTimelineQueryCase(t, `sort-direction:desc`, helpers.TimelineFilters{
+	testTimelineQueryCase(t, `sort:desc`, helpers.TimelineFilters{
 		SortAsc: false,
 	})
 	testTimelineQueryCase(t, ``, helpers.TimelineFilters{
@@ -101,7 +101,7 @@ func TestParseTimelineQuery(t *testing.T) {
 	testTimelineQueryExpectErr(t, `multiple uuids           cause error uuid:ABC123 uuid:XYZ789`) // actual uuid doesn't currently matter
 	testTimelineQueryExpectErr(t, `multiple with_evidence   cause error with-evidence:ABC123 with-evidence:XYZ789`)
 	testTimelineQueryExpectErr(t, `multiple linked          cause error linked:all linked:true`)
-	testTimelineQueryExpectErr(t, `multiple sort_directions cause error sort-direction:desc sort-direction:asc`)
+	testTimelineQueryExpectErr(t, `multiple sort_directions cause error sort:desc sort:asc`)
 	testTimelineQueryExpectErr(t, `unparsable bool/not all cause error linked:maybe`)
 	testTimelineQueryExpectErr(t, `unparsable date cause error range:2021-01-01,2021-02-31`)
 	testTimelineQueryExpectErr(t, `unparsable date cause error (alt) range:2021-01-01`)

--- a/backend/helpers/query_parser_test.go
+++ b/backend/helpers/query_parser_test.go
@@ -95,7 +95,7 @@ func TestParseTimelineQuery(t *testing.T) {
 	testTimelineQueryCase(t, ``, helpers.TimelineFilters{
 		SortAsc: false,
 	})
-	
+
 	testTimelineQueryExpectErr(t, `invalid keys cause error invalid:value`)
 	testTimelineQueryExpectErr(t, `multiple operators       cause error operator:alice operator:bob`)
 	testTimelineQueryExpectErr(t, `multiple uuids           cause error uuid:ABC123 uuid:XYZ789`) // actual uuid doesn't currently matter

--- a/backend/services/list_evidence_for_operation.go
+++ b/backend/services/list_evidence_for_operation.go
@@ -43,8 +43,13 @@ func ListEvidenceForOperation(ctx context.Context, db *database.Connection, i Li
 
 	sb := sq.Select("evidence.id", "evidence.uuid", "description", "evidence.content_type", "occurred_at", "users.first_name", "users.last_name", "users.slug").
 		From("evidence").
-		LeftJoin("users ON evidence.operator_id = users.id").
-		OrderBy("occurred_at DESC")
+		LeftJoin("users ON evidence.operator_id = users.id")
+
+	if i.Filters.SortAsc {
+		sb = sb.OrderBy("occurred_at ASC")
+	} else {
+		sb = sb.OrderBy("occurred_at DESC")
+	}
 
 	sb = buildListEvidenceWhereClause(sb, operation.ID, i.Filters)
 


### PR DESCRIPTION
This PR adds the ability to order the timeline results in an ascending or descending (current, default) order, by time, when adding a new parameter to the search query.

Users may now add to the search the following:
`sort-direction:asc` to order in an ascending fashion (first-to-happen view). Instead of `asc`, you may provide synonyms: `chronological` or `ascending`. All of these values are case insensitive
Any other value (or not specifying this field) returns the same results in a descending fashion (most recently occurred first)

This can be  used on any timeline view, and will kept for saved queries.

Note: Currently, all of the mock data occurs at the same time, so the sorting will not be obvious for these records -- add new evidence to test this feature.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.