### PR TITLE
Log out user after their system state changes

### DIFF
--- a/backend/session/store.go
+++ b/backend/session/store.go
@@ -69,7 +69,14 @@ func (store *Store) readRaw(r *http.Request) *sessions.Session {
 func userIDFromSession(sess *sessions.Session) *int64 {
 	sessionData, ok := sess.Values[sessionDataKey].(*Session)
 	if ok {
-		return &sessionData.UserID
+		val := sessionData.UserID
+		// userIDs start at 1. In some cases, the UserID won't be set and will be 0
+		// trying to add a row with userID 0 will result in a foreign key constraint error, so
+		// returning nil ("no user id") instead
+		if val != 0 {
+			return &val
+		}
+		return nil
 	}
 	return nil
 }

--- a/backend/session/store.go
+++ b/backend/session/store.go
@@ -34,6 +34,7 @@ func NewStore(db *database.Connection, opts StoreOptions) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
+	wrappedStore.SetSessionToUserID(userIDFromSession)
 	wrappedStore.Options.Path = "/"
 	wrappedStore.Options.HttpOnly = true
 	wrappedStore.Options.Secure = opts.UseSecureCookies
@@ -63,4 +64,12 @@ func (store *Store) Delete(w http.ResponseWriter, r *http.Request) error {
 func (store *Store) readRaw(r *http.Request) *sessions.Session {
 	sess, _ := store.wrappedStore.Get(r, "auth") // ignoring, because errors only fire if a bad cookie name is provided
 	return sess
+}
+
+func userIDFromSession(sess *sessions.Session) *int64 {
+	sessionData, ok := sess.Values[sessionDataKey].(*Session)
+	if ok {
+		return &sessionData.UserID
+	}
+	return nil
 }


### PR DESCRIPTION
This PR provides the ability to log  out a user when that  user's  "user flags" are changed. Specifically, when a user moves from a normal user to either a disabled user/admin user, or from one of those states back to a normal user (or really any combination of admin/disabled flag changes).

This fixes a bug and restores previous functionality that had been lost along the way.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.