### PR TITLE
remove print margin  on codeblocks

### DIFF
--- a/frontend/src/components/code_block/ace_editor/index.tsx
+++ b/frontend/src/components/code_block/ace_editor/index.tsx
@@ -30,6 +30,7 @@ export default (props: {
         {...editorSize}
         mode={mode}
         theme="ashirt"
+        showPrintMargin={false}
         editorProps={{ $blockScrolling: true }}
       />
     </div>


### PR DESCRIPTION
This PR removes the "print margin" (vertical line on the right hand side of the code editor).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.