### PR TITLE
Allow for closing local registration, allow admin to create new local users

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -84,6 +84,42 @@ One limitation to this behavior is that, generally speaking, admins cannot alter
 
 When a fresh system is deployed, no users are present, thus no admins are present either. The first administration account, therefore, is granted to the first user that registers within the system.
 
+###### First Admin alternative
+
+In certain situations, there may not be a way for a new user to register with AShirt without an
+admin's help, even for the first user. In these cases, the below SQL can be used to create an initial
+account and a recovery code to link the account to a supported authentication scheme.
+
+Note that this requires direct access to the database. This should only be done for the first user
+when the normal approach will not work.
+
+1. Edit, and execute the below SQL
+
+  ```sql
+  INSERT INTO users (slug, first_name, last_name, email, admin) VALUES
+  ('user@example.com', 'User', 'McUserface', 'user@example.com', true);
+
+  INSERT INTO auth_scheme_data (auth_scheme, user_key, user_id) VALUES
+  ('recovery', 'e3c6ead16e0c25820ba730f278ef54133da5610f9bf1d2e481ff6693c8df85123a29b8dc1f033a2f', 1);
+  ```
+
+  This will add a one-time password to AShirt which will allow the admin to sign in. Note that,
+  per convention, the slug and email should match if using ASHIRT Local Authentication. This is not
+  a hard requirement if you want to deviate from the convention. All other fields can be updated by
+  updating the profile in Account Settings.
+
+2. Start up the AShirt frontend and backend, if not already started
+3. Once started, edit, and navigate to: `http://MY_ASHIRT_DOMAIN/web/auth/recovery/login?code=e3c6ead16e0c25820ba730f278ef54133da5610f9bf1d2e481ff6693c8df85123a29b8dc1f033a2f`
+
+The admin should now be logged in, and can update their security information.
+
+1. Click the person icon and select "Account Settings"
+2. Go to "Authentication Methods"
+3. Find a supported login the admin wishes to use, and click the "Link" button. Follow this process.
+   1. Note: if linking to ASHIRT Local Authentication, when the admin logs in, they will log in via the email address provided during the linking step, not (necessarily) the above sql script.
+
+At this point, a proper admin account exists and you can log in via the linked methods.
+
 #### Custom Authentication
 
 Adding your own authentication is a 3 step process:

--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -39,10 +39,17 @@ Configuration is handled entirely via environment variables. To that end, here a
     * Expected type: time duration (e.g. `60m` => 60 minutes `24h` => 24 hours)
     * Defaults to 24 hours
     * Base unit is 1 minute. Fractional minutes will be ignored
+  * `APP_DISABLE_LOCAL_REGISTRATION`
+    * Removes the registration aspect of local auth. Users will still be able to log in if they already have a local auth account.
+    * Valid Options: `"true"` or `"false"`
+    * Admins can provision new local auth accounts to provide access to new users.
+    * Only valid if deploying using `ashirt` authentication. Otherwise has no effect
   * `AUTH_SERVICES`
     * Defines what authentication services are supported on the backend. This is limited by what the backend naturally supports.
     * Values must be comma separated (though commas are only needed when multiple values are used)
-    * Example value: `ashirt,google,github`
+    * Example value: `ashirt,otka`
+    * Currently valid values: `ashirt`, `okta`
+      * This list will likely become outdated over time. Consult the authschemes directory for a better idea of what is supported.
   * `AUTH_${SERVICE}_` Variables
     * These environment variables are namespaced per Auth Service. Each of these is a specific field that can be used to pass configuration details to the authentication service. Note that `${SERVICE}` must be replaced with a proper string, expected in all caps. For example `AUTH_GITHUB`, `AUTH_ASHIRT`, `AUTH_GOOGLE`
     * `AUTH_${SERVICE}_CLIENT_ID`
@@ -75,7 +82,7 @@ One limitation to this behavior is that, generally speaking, admins cannot alter
 
 ##### First Admin
 
-When a fresh system is deployed, no users are present, thus no admins are present either. The first administration, therefore, is granted to the first user that registers a system.
+When a fresh system is deployed, no users are present, thus no admins are present either. The first administration account, therefore, is granted to the first user that registers within the system.
 
 #### Custom Authentication
 

--- a/backend/authschemes/auth_bridge.go
+++ b/backend/authschemes/auth_bridge.go
@@ -188,11 +188,12 @@ func (ah AShirtAuthBridge) FindUserAuthsByUserSlug(slug string) ([]UserAuthData,
 // if any other issue occurs
 func (ah AShirtAuthBridge) CreateNewAuthForUser(data UserAuthData) error {
 	_, err := ah.db.Insert("auth_scheme_data", map[string]interface{}{
-		"auth_scheme":        ah.authSchemeName,
-		"user_key":           data.UserKey,
-		"user_id":            data.UserID,
-		"encrypted_password": data.EncryptedPassword,
-		"totp_secret":        data.TOTPSecret,
+		"auth_scheme":         ah.authSchemeName,
+		"user_key":            data.UserKey,
+		"user_id":             data.UserID,
+		"encrypted_password":  data.EncryptedPassword,
+		"totp_secret":         data.TOTPSecret,
+		"must_reset_password": data.NeedsPasswordReset,
 	})
 	if err != nil {
 		if database.IsAlreadyExistsError(err) {

--- a/backend/authschemes/auth_scheme.go
+++ b/backend/authschemes/auth_scheme.go
@@ -26,4 +26,5 @@ type AuthScheme interface {
 	BindRoutes(*mux.Router, AShirtAuthBridge)
 	Name() string
 	FriendlyName() string
+	Flags() []string
 }

--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -106,7 +106,7 @@ func (p LocalAuthScheme) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuth
 		if _, err := rand.Read(authKey); err != nil {
 			return nil, backend.WrapError("Unable to generate random new user password key", err)
 		}
-		
+
 		// convert authKey into readable format
 		bufKey := make([]byte, len(authKey))
 		for i, b := range authKey {

--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -108,11 +108,7 @@ func (p LocalAuthScheme) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuth
 		}
 
 		// convert authKey into readable format
-		bufKey := make([]byte, len(authKey))
-		for i, b := range authKey {
-			bufKey[i] = (b % (126 - 33)) + 33
-		}
-		readKey := base64.StdEncoding.EncodeToString(bufKey)
+		readKey := base64.StdEncoding.EncodeToString(authKey)
 
 		dr := remux.DissectJSONRequest(r)
 		info := RegistrationInfo{

--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -5,6 +5,7 @@ package localauth
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -101,15 +102,17 @@ func (p LocalAuthScheme) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuth
 			return nil, backend.UnauthorizedWriteErr(fmt.Errorf("Requesting user is not an admin"))
 		}
 
-		authKey := make([]byte, 40)
+		authKey := make([]byte, 42)
 		if _, err := rand.Read(authKey); err != nil {
 			return nil, backend.WrapError("Unable to generate random new user password key", err)
 		}
-		// convert authKey into readable range (33-126)
-		readKey := make([]byte, len(authKey))
+		
+		// convert authKey into readable format
+		bufKey := make([]byte, len(authKey))
 		for i, b := range authKey {
-			readKey[i] = (b % (126 - 33)) + 33
+			bufKey[i] = (b % (126 - 33)) + 33
 		}
+		readKey := base64.StdEncoding.EncodeToString(bufKey)
 
 		dr := remux.DissectJSONRequest(r)
 		info := RegistrationInfo{

--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-type LocalAuthScheme struct{
+type LocalAuthScheme struct {
 	RegistrationEnabled bool
 }
 
@@ -30,6 +30,18 @@ func (LocalAuthScheme) Name() string {
 // FriendlyName returns "ASHIRT Local Authentication"
 func (LocalAuthScheme) FriendlyName() string {
 	return constants.FriendlyName
+}
+
+// Flags returns auth flags associated with local auth
+// in particular, notes if registration is open or closed
+func (s LocalAuthScheme) Flags() []string {
+	flags := make([]string, 0)
+
+	if s.RegistrationEnabled {
+		flags = append(flags, "open-registration")
+	}
+
+	return flags
 }
 
 // BindRoutes creates many routes for local database routes:

--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -18,7 +18,9 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-type LocalAuthScheme struct{}
+type LocalAuthScheme struct{
+	RegistrationEnabled bool
+}
 
 // Name returns the name of this authscheme
 func (LocalAuthScheme) Name() string {
@@ -56,6 +58,10 @@ func (LocalAuthScheme) FriendlyName() string {
 // the underlying system/database
 func (p LocalAuthScheme) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge) {
 	remux.Route(r, "POST", "/register", remux.JSONHandler(func(r *http.Request) (interface{}, error) {
+		if !p.RegistrationEnabled {
+			return nil, fmt.Errorf("registration is closed to users")
+		}
+
 		dr := remux.DissectJSONRequest(r)
 		firstName := dr.FromBody("firstName").Required().AsString()
 		lastName := dr.FromBody("lastName").Required().AsString()

--- a/backend/authschemes/oktaauth/okta_auth.go
+++ b/backend/authschemes/oktaauth/okta_auth.go
@@ -84,6 +84,11 @@ func (OktaAuth) FriendlyName() string {
 	return "Okta OIDC"
 }
 
+// Flags returns an empty string (no supported auth flags for okta)
+func (OktaAuth) Flags() []string {
+	return []string{}
+}
+
 func (okta OktaAuth) authSuccess(w http.ResponseWriter, r *http.Request, linking bool) (interface{}, error) {
 	if linking {
 		return authDone(w, r, "/account/authmethods", nil)

--- a/backend/authschemes/recoveryauth/recovery_auth.go
+++ b/backend/authschemes/recoveryauth/recovery_auth.go
@@ -34,6 +34,11 @@ func (RecoveryAuthScheme) FriendlyName() string {
 	return constants.FriendlyName
 }
 
+// Flags returns an empty string (no supported auth flags for recovery)
+func (RecoveryAuthScheme) Flags() []string {
+	return []string{}
+}
+
 func (p RecoveryAuthScheme) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge) {
 	remux.Route(r, "POST", "/generate", remux.JSONHandler(func(r *http.Request) (interface{}, error) {
 		dr := remux.DissectJSONRequest(r)

--- a/backend/bin/dev/dev.go
+++ b/backend/bin/dev/dev.go
@@ -63,7 +63,9 @@ func tryRunServer(logger logging.Logger) error {
 	for _, svc := range config.SupportedAuthServices() {
 		switch svc {
 		case "ashirt":
-			schemes = append(schemes, localauth.LocalAuthScheme{})
+			schemes = append(schemes, localauth.LocalAuthScheme{
+				RegistrationEnabled: config.IsRegistrationEnabled(),
+			})
 		case "okta":
 			schemes = append(schemes, oktaauth.NewFromConfig(
 				config.AuthConfigInstance(svc),

--- a/backend/bin/web/web.go
+++ b/backend/bin/web/web.go
@@ -45,7 +45,9 @@ func main() {
 	for _, svc := range config.SupportedAuthServices() {
 		switch svc {
 		case "ashirt":
-			schemes = append(schemes, localauth.LocalAuthScheme{})
+			schemes = append(schemes, localauth.LocalAuthScheme{
+				RegistrationEnabled: config.IsRegistrationEnabled(),
+			})
 		case "okta":
 			schemes = append(schemes, oktaauth.NewFromConfig(
 				config.AuthConfigInstance(svc),

--- a/backend/config/webconfig.go
+++ b/backend/config/webconfig.go
@@ -15,12 +15,13 @@ import (
 
 // WebConfig is a namespaced app-specific configuration.
 type WebConfig struct {
-	ImgstoreBucketName string        `split_words:"true"`
-	ImgstoreRegion     string        `split_words:"true"`
-	CsrfAuthKey        string        `split_words:"true"`
-	SessionStoreKey    string        `split_words:"true"`
-	RecoveryExpiry     time.Duration `split_words:"true" default:"24h"`
-	Port               int
+	ImgstoreBucketName       string        `split_words:"true"`
+	ImgstoreRegion           string        `split_words:"true"`
+	CsrfAuthKey              string        `split_words:"true"`
+	SessionStoreKey          string        `split_words:"true"`
+	RecoveryExpiry           time.Duration `split_words:"true" default:"24h"`
+	DisableLocalRegistration bool          `split_words:"true"`
+	Port                     int
 }
 
 // DBConfig provides configuration details on connecting to the backend database
@@ -175,4 +176,9 @@ func Port() string {
 // RecoveryExpiry retrieves the APP_RECOVERY_EXPIRY value from the environment
 func RecoveryExpiry() time.Duration {
 	return app.RecoveryExpiry
+}
+
+// IsRegistrationEnabled returns true if local registration is enabled, false otherwise.
+func IsRegistrationEnabled() bool {
+	return !app.DisableLocalRegistration
 }

--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -116,6 +116,7 @@ type PaginationWrapper struct {
 type DetailedAuthenticationInfo struct {
 	AuthSchemeName  string     `json:"schemeName"`
 	AuthSchemeCode  string     `json:"schemeCode"`
+	AuthSchemeFlags []string   `json:"schemeFlags"`
 	UserCount       int64      `json:"userCount"`
 	UniqueUserCount int64      `json:"uniqueUserCount"`
 	LastUsed        *time.Time `json:"lastUsed"`
@@ -123,8 +124,9 @@ type DetailedAuthenticationInfo struct {
 }
 
 type SupportedAuthScheme struct {
-	SchemeName string `json:"schemeName"`
-	SchemeCode string `json:"schemeCode"`
+	SchemeName  string   `json:"schemeName"`
+	SchemeCode  string   `json:"schemeCode"`
+	SchemeFlags []string `json:"schemeFlags"`
 }
 
 type TagDifference struct {

--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -147,3 +147,7 @@ type TagByEvidenceDate struct {
 type CheckConnection struct {
 	Ok bool `json:"ok"`
 }
+
+type NewUserCreatedByAdmin struct {
+	TemporaryPassword string `json:"temporaryPassword"`
+}

--- a/backend/dtos/gentypes/generate_typescript_types.go
+++ b/backend/dtos/gentypes/generate_typescript_types.go
@@ -35,6 +35,7 @@ func main() {
 	gen(dtos.TagDifference{})
 	gen(dtos.TagByEvidenceDate{})
 	gen(dtos.CheckConnection{})
+	gen(dtos.NewUserCreatedByAdmin{})
 
 	// Since this file only contains typescript types, webpack doesn't pick up the
 	// changes unless there is some actual executable javascript referenced from

--- a/backend/integration/helpers.go
+++ b/backend/integration/helpers.go
@@ -48,8 +48,10 @@ func NewTester(t *testing.T) *Tester {
 		db, contentStore, &server.WebConfig{
 			CSRFAuthKey:     []byte("csrf-auth-key-for-integration-tests"),
 			SessionStoreKey: []byte("session-store-key-for-integration-tests"),
-			AuthSchemes:     []authschemes.AuthScheme{localauth.LocalAuthScheme{}},
-			Logger:          commonLogger,
+			AuthSchemes: []authschemes.AuthScheme{localauth.LocalAuthScheme{
+				RegistrationEnabled: true,
+			}},
+			Logger: commonLogger,
 		},
 	)))
 	s.Handle("/api/", server.API(

--- a/backend/server/web.go
+++ b/backend/server/web.go
@@ -84,7 +84,11 @@ func Web(db *database.Connection, contentStore contentstore.Store, config *WebCo
 	for i, scheme := range config.AuthSchemes {
 		authRouter := r.PathPrefix("/auth/" + scheme.Name()).Subrouter()
 		scheme.BindRoutes(authRouter, authschemes.MakeAuthBridge(db, sessionStore, scheme.Name()))
-		supportedAuthSchemes[i] = dtos.SupportedAuthScheme{SchemeName: scheme.FriendlyName(), SchemeCode: scheme.Name()}
+		supportedAuthSchemes[i] = dtos.SupportedAuthScheme{
+			SchemeName:  scheme.FriendlyName(),
+			SchemeCode:  scheme.Name(),
+			SchemeFlags: scheme.Flags(),
+		}
 	}
 	authsWithOutRecovery := make([]dtos.SupportedAuthScheme, 0, len(supportedAuthSchemes)-1)
 

--- a/backend/services/list_auths_details.go
+++ b/backend/services/list_auths_details.go
@@ -82,9 +82,10 @@ func mergeSchemes(foundSchemes []detailedSchemeTable, supportedAuthSchemes *[]dt
 	// Add schemes that are supported (whether used or not)
 	for _, scheme := range clonedSchemes {
 		schemes = append(schemes, &dtos.DetailedAuthenticationInfo{
-			AuthSchemeName: scheme.SchemeName,
-			AuthSchemeCode: scheme.SchemeCode,
-			Labels:         []string{},
+			AuthSchemeName:  scheme.SchemeName,
+			AuthSchemeCode:  scheme.SchemeCode,
+			AuthSchemeFlags: scheme.SchemeFlags,
+			Labels:          []string{},
 		})
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       APP_CSRF_AUTH_KEY: ""
       APP_SESSION_STORE_KEY: ""
       APP_PORT: 3000
+      APP_DISABLE_LOCAL_REGISTRATION: "false"
       DB_URI: dev-user:dev-user-password@tcp(db:3306)/dev-db
       AUTH_SERVICES: ashirt
       AUTH_OKTA_CLIENT_ID:

--- a/frontend/Readme.md
+++ b/frontend/Readme.md
@@ -16,6 +16,7 @@ In addition to the above, the following features are supported:
 
 * Admin accounts
   * Admins have special access to the system. They can view all users, reset password, and edit any operation settings.
+  * Admins gain access to these functions, and more, by choosing the person icon, and selecting "Admin"
 * Robust searching
   * Sort by tag, date range or description
 * Saving searches for evidence and findings (on a per-operation basis)

--- a/frontend/src/authschemes/index.tsx
+++ b/frontend/src/authschemes/index.tsx
@@ -6,9 +6,9 @@ import { ParsedUrlQuery } from 'querystring'
 import { useAsyncComponent } from 'src/helpers'
 
 export type AuthFrontend = {
-  Linker: React.FunctionComponent<{ onSuccess: () => void }>,
-  Login: React.FunctionComponent<{ query: ParsedUrlQuery }>,
-  Settings: React.FunctionComponent<{ userKey: string }>,
+  Linker: React.FunctionComponent<{ onSuccess: () => void, authFlags?: Array<string> }>,
+  Login: React.FunctionComponent<{ query: ParsedUrlQuery, authFlags?: Array<string> }>,
+  Settings: React.FunctionComponent<{ userKey: string, authFlags?: Array<string> }>,
 }
 
 // @ts-ignore - this is a webpack compile-time include of src/authschemes/*/index.ts

--- a/frontend/src/authschemes/local/linker/index.tsx
+++ b/frontend/src/authschemes/local/linker/index.tsx
@@ -10,6 +10,7 @@ import Input from 'src/components/input'
 
 export default (props: {
   onSuccess: () => void,
+  authFlags?: Array<string>,
 }) => {
   const email = useFormField<string>('')
   const password = useFormField<string>('')

--- a/frontend/src/authschemes/local/login/index.tsx
+++ b/frontend/src/authschemes/local/login/index.tsx
@@ -38,11 +38,12 @@ function getValueAndClear(field: {value: string, onChange: (s: string) => void})
 
 export default (props: {
   query: ParsedUrlQuery,
+  authFlags?: Array<string>
 }) => {
   switch (props.query.step) {
     case 'reset': return <ResetPassword />
     case 'totp': return <EnterTotp />
-    default: return <Login />
+    default: return <Login authFlags={props.authFlags} />
   }
 }
 

--- a/frontend/src/authschemes/local/login/index.tsx
+++ b/frontend/src/authschemes/local/login/index.tsx
@@ -48,6 +48,7 @@ export default (props: {
 }
 
 const Login = (props: {
+  authFlags?: Array<string>
 }) => {
   const emailField = useFormField('')
   const passwordField = useFormField('')
@@ -61,9 +62,14 @@ const Login = (props: {
 
   const registerModal = useModal<void>(modalProps => <RegisterModal {...modalProps} />)
 
+  const allowRegister = props.authFlags?.includes("open-registration")
+  const registerProps = allowRegister
+    ? {cancelText: "Register", onCancel: ()=> registerModal.show()}
+    : {}
+
   return (
     <div style={{minWidth: 300}}>
-      <Form submitText="Login" cancelText="Register" onCancel={() => registerModal.show()} {...loginForm}>
+      <Form submitText="Login" {...registerProps} {...loginForm}>
         <Input label="Email" {...emailField} />
         <Input label="Password" type="password" {...passwordField} />
       </Form>

--- a/frontend/src/authschemes/local/settings/index.tsx
+++ b/frontend/src/authschemes/local/settings/index.tsx
@@ -13,6 +13,7 @@ const cx = classnames.bind(require('./stylesheet'))
 
 export default (props: {
   userKey: string,
+  authFlags?: Array<string>
 }) => <>
   <h1 className={cx('header')}>Settings for local account <span className={cx('user-key')}>{props.userKey}</span></h1>
   <SettingsSection title="Change Password" width="narrow">

--- a/frontend/src/authschemes/okta/linker/index.tsx
+++ b/frontend/src/authschemes/okta/linker/index.tsx
@@ -7,6 +7,7 @@ import Button from 'src/components/button'
 
 export default (props: {
   onSuccess: () => void,
+  authFlags?: Array<string>
 }) => (
   <Button primary onClick={(e) => { e.preventDefault(); window.location.href = "/web/auth/okta/link" }}>Login with Okta</Button >
 )

--- a/frontend/src/authschemes/okta/login/index.tsx
+++ b/frontend/src/authschemes/okta/login/index.tsx
@@ -9,6 +9,7 @@ const loginWithOkta = () => {
 }
 
 export default (props: {
+  authFlags?: Array<string>
 }) => (
   <div style={{textAlign: 'right'}}>
     <Button primary onClick={loginWithOkta}>Login With Okta</Button>

--- a/frontend/src/global_types.ts
+++ b/frontend/src/global_types.ts
@@ -180,6 +180,7 @@ export type PaginationResult<T> = PaginationQuery & {
 export type SupportedAuthenticationScheme = {
   schemeName: string,
   schemeCode: string,
+  schemeFlags: Array<string>
 }
 
 export type AuthSchemeDetails = SupportedAuthenticationScheme & {

--- a/frontend/src/pages/account_settings/auth_methods/index.tsx
+++ b/frontend/src/pages/account_settings/auth_methods/index.tsx
@@ -97,10 +97,13 @@ const TableRow = (props: {
       </td>
       {linking && (
         <Modal onRequestClose={() => setLinking(false)} title={"Link Account"}>
-          <Linker onSuccess={() => {
-            setLinking(false)
-            props.requestReload && props.requestReload()
-          }} />
+          <Linker
+            onSuccess={() => {
+              setLinking(false)
+              props.requestReload && props.requestReload()
+            }}
+            authFlags={props.supportedScheme.schemeFlags}
+          />
         </Modal>
       )}
     </tr>

--- a/frontend/src/pages/account_settings/security/index.tsx
+++ b/frontend/src/pages/account_settings/security/index.tsx
@@ -27,6 +27,7 @@ const AuthSchemeSettings = (props: {
 }) => {
   const Settings = useAuthFrontendComponent(props.authSchemeCode, 'Settings')
   return (
-    <Settings userKey={props.userKey} />
+    // TODO: we should figure out how to get flag info below
+    <Settings userKey={props.userKey} authFlags={[]} />
   )
 }

--- a/frontend/src/pages/admin/add_user/index.tsx
+++ b/frontend/src/pages/admin/add_user/index.tsx
@@ -1,0 +1,28 @@
+// Copyright 2021, Verizon Media
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+import * as React from 'react'
+import Button from 'src/components/button'
+import SettingsSection from 'src/components/settings_section'
+import { AddUserModal } from 'src/pages/admin_modals'
+
+export default (props: {
+  requestReload?: () => void
+}) => {
+  const [newUser, setNewUser] = React.useState<boolean>(false)
+
+  return (
+    <SettingsSection title="New User Creation">
+      <em>
+        Pre-provision accounts for expected users.
+        This will create a local authentication account, and provide their first password.
+        Users will be forced to reset their password on their next login.
+      </em>
+      <Button primary onClick={() => setNewUser(true)}>Create New User</Button>
+      {newUser && <AddUserModal onRequestClose={() => {
+        setNewUser(false)
+        props.requestReload && props.requestReload()
+      }} />}
+    </SettingsSection>
+  )
+}

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -7,6 +7,7 @@ import { RouteComponentProps } from 'react-router-dom'
 
 import AuthTable from './auth_table'
 import HeadlessButton from './add_headless'
+import CreateUserButton from "./add_user"
 import NavVerticalTab from 'src/components/tab_vertical_menu'
 import OperationsTable from './operations_table'
 import RecoveryMetrics from './recovery_metrics'
@@ -28,6 +29,7 @@ export default (props: RouteComponentProps) => {
             id: "users", label: "User Management", content: <>
               <UserTable {...bus} />
               <HeadlessButton {...bus} />
+              <CreateUserButton {...bus} />
             </>
           },
           {

--- a/frontend/src/pages/admin_modals/stylesheet.styl
+++ b/frontend/src/pages/admin_modals/stylesheet.styl
@@ -8,3 +8,11 @@
   font-style: italic
   display: block
   color: $operation-status-colors['0']
+
+.success-close-button
+  float: right
+  margin-bottom: 20px
+
+.success-area
+  & > *
+    margin-top: 10px

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -21,13 +21,14 @@ export default (props: RouteComponentProps<{ schemeCode?: string }>) => {
 
   return wiredAuthSchemes.render(supportedAuthSchemes => (
     <div className={cx('login')}>
-      {supportedAuthSchemes.map(({schemeCode}) => {
+      {supportedAuthSchemes.map(({schemeCode, schemeFlags}) => {
         if (renderOnlyScheme != null && schemeCode != renderOnlyScheme) return null
         return (
           <AuthSchemeLogin
             key={schemeCode}
             authSchemeCode={schemeCode}
             query={query}
+            authSchemeFlags={schemeFlags}
           />
         )
       })}
@@ -38,12 +39,13 @@ export default (props: RouteComponentProps<{ schemeCode?: string }>) => {
 
 const AuthSchemeLogin = (props: {
   authSchemeCode: string,
+  authSchemeFlags: Array<string>
   query: ParsedUrlQuery,
 }) => {
   const Login = useAuthFrontendComponent(props.authSchemeCode, 'Login')
   return (
     <div className={cx('auth-scheme-row')}>
-      <Login query={props.query} />
+      <Login query={props.query} authFlags={props.authSchemeFlags}/>
     </div>
   )
 }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -57,6 +57,7 @@ export async function getSupportedAuthenticationDetails(): Promise<Array<AuthSch
   return schemes.map(details => ({
     schemeName: details.schemeName,
     schemeCode: details.schemeCode,
+    schemeFlags: details.schemeFlags,
     userCount: details.userCount,
     uniqueUserCount: details.uniqueUserCount,
     labels: details.labels,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -28,6 +28,15 @@ export async function adminChangePassword(i: {
   await ds.adminChangePassword(i)
 }
 
+// TODO this should be encapsulated in an admin settings component under src/authschemes/local
+export async function adminCreateLocalUser(i: {
+  firstName: string,
+  lastName?: string,
+  email: string,
+}) {
+  return await ds.adminCreateLocalUser(i)
+}
+
 export async function logout() {
   await ds.logout()
 }

--- a/frontend/src/services/data_sources/backend/index.ts
+++ b/frontend/src/services/data_sources/backend/index.ts
@@ -67,6 +67,7 @@ export const backendDataSource: DataSource = {
   deleteExpiredRecoveryCodes: () => req('DELETE', '/auth/recovery/expired'),
   getRecoveryMetrics: () => req('GET', '/auth/recovery/metrics'),
   adminChangePassword: i => req('PUT', '/auth/local/admin/password', i),
+  adminCreateLocalUser: i => req('POST', '/auth/local/admin/register', i),
   getTotpForUser: ids =>  req('GET', '/auth/local/totp', ids),
   deleteTotpForUser: ids => req('DELETE', '/auth/local/totp', ids),
 }

--- a/frontend/src/services/data_sources/data_source.ts
+++ b/frontend/src/services/data_sources/data_source.ts
@@ -85,6 +85,7 @@ export interface DataSource {
   deleteExpiredRecoveryCodes(): Promise<void>
   getRecoveryMetrics(): Promise<any>
   adminChangePassword(i: { userSlug: string, newPassword: string }): Promise<void>
+  adminCreateLocalUser(i: { firstName: string, lastName?: string, email: string }): Promise<dtos.NewUserCreatedByAdmin>,
   getTotpForUser(ids: UserSlug): Promise<boolean>
   deleteTotpForUser(ids: UserSlug): Promise<void>
 }


### PR DESCRIPTION
This PR does two things: First, it adds a new startup flag that will disable local registration. Second, it allows admins to create new user accounts for users on their behalf. Documentation has been provided to indicate how to turn on this feature, and some revised instructions has been provided on how to register the first account (especially when local auth registration is blocked)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.