### PR TITLE
Use finding_categories relation for a finding's category

### DIFF
--- a/backend/database/seeding/helpers.go
+++ b/backend/database/seeding/helpers.go
@@ -170,14 +170,14 @@ func newFindingCategoryGen(first int64) func(category string, deleted bool) mode
 	}
 }
 
-func newFindingGen(first int64) func(opID int64, uuid, category, title, desc string, ticketLink *string) models.Finding {
+func newFindingGen(first int64) func(opID int64, uuid string, category *int64, title, desc string, ticketLink *string) models.Finding {
 	id := iotaLike(first)
-	return func(opID int64, uuid, category, title, desc string, ticketLink *string) models.Finding {
+	return func(opID int64, uuid string, category *int64, title, desc string, ticketLink *string) models.Finding {
 		finding := models.Finding{
 			ID:            id(),
 			OperationID:   opID,
 			UUID:          uuid,
-			Category:      category,
+			CategoryID:    category,
 			Title:         title,
 			Description:   desc,
 			ReadyToReport: (ticketLink != nil),

--- a/backend/database/seeding/hp_seed_data.go
+++ b/backend/database/seeding/hp_seed_data.go
@@ -13,7 +13,7 @@ import (
 var HarryPotterSeedData = Seeder{
 	FindingCategories: []models.FindingCategory{
 		ProductFindingCategory, NetworkFindingCategory, EnterpriseFindingCategory, VendorFindingCategory, BehavioralFindingCategory, DetectionGapFindingCategory,
-		DeletedCategory,
+		DeletedCategory, SomeFindingCategory, SomeOtherFindingCategory,
 	},
 	Users: []models.User{UserHarry, UserRon, UserGinny, UserHermione, UserNeville, UserSeamus, UserDraco, UserSnape, UserDumbledore, UserHagrid, UserTomRiddle, UserHeadlessNick,
 		UserCedric, UserFleur, UserViktor, UserAlastor, UserMinerva, UserLucius, UserSirius, UserPeter, UserParvati, UserPadma, UserCho,
@@ -89,7 +89,7 @@ var HarryPotterSeedData = Seeder{
 		newUserOpPermission(UserGinny, OpGanttChart, policy.OperationRoleRead),
 	},
 	Findings: []models.Finding{
-		FindingBook2Magic, FindingBook2CGI, FindingBook2SpiderFear,
+		FindingBook2Magic, FindingBook2CGI, FindingBook2SpiderFear, FindingBook2Robes,
 	},
 	Evidences: []models.Evidence{
 		EviDursleys, EviMirrorOfErised, EviLevitateSpell, EviRulesForQuidditch,
@@ -398,13 +398,6 @@ var newHPQuery = newQueryGen(1)
 var QuerySalazarsHier = newHPQuery(OpChamberOfSecrets.ID, "Find Heir", "Magic Query String", "findings")
 var QueryWhereIsTheChamberOfSecrets = newHPQuery(OpChamberOfSecrets.ID, "Locate Chamber", "Fancy Query", "evidence")
 
-var newHPFinding = newFindingGen(1)
-var noLink = ""
-var spiderLink = "https://www.google.com/search?q=spider+predators"
-var FindingBook2Magic = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-b2magic", "some-category", "lots o' magic", "Magic plagues Harry's life", nil)
-var FindingBook2CGI = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-cgi", "alt-category", "this looks fake", "I'm not entirely sure this is all above board", &noLink)
-var FindingBook2SpiderFear = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-spider", "some-category", "how to scare spiders", "Who would have thought?", &spiderLink)
-
 var newHpFindingCategory = newFindingCategoryGen(1)
 
 var ProductFindingCategory = newHpFindingCategory("Product", false)
@@ -413,4 +406,14 @@ var EnterpriseFindingCategory = newHpFindingCategory("Enterprise", false)
 var VendorFindingCategory = newHpFindingCategory("Vendor", false)
 var BehavioralFindingCategory = newHpFindingCategory("Behavioral", false)
 var DetectionGapFindingCategory = newHpFindingCategory("Detection Gap", false)
+var SomeFindingCategory = newHpFindingCategory("some-category", false)
+var SomeOtherFindingCategory = newHpFindingCategory("alt-category", false)
 var DeletedCategory = newHpFindingCategory("I was deleted", true)
+
+var newHPFinding = newFindingGen(1)
+var noLink = ""
+var spiderLink = "https://www.google.com/search?q=spider+predators"
+var FindingBook2Magic = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-b2magic", &SomeFindingCategory.ID, "lots o' magic", "Magic plagues Harry's life", nil)
+var FindingBook2CGI = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-cgi", &SomeOtherFindingCategory.ID, "this looks fake", "I'm not entirely sure this is all above board", &noLink)
+var FindingBook2SpiderFear = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-spider", &SomeFindingCategory.ID, "how to scare spiders", "Who would have thought?", &spiderLink)
+var FindingBook2Robes = newHPFinding(OpChamberOfSecrets.ID, "find-uuid-robes", nil, "Robes for all seasons", "Turns out there's only one kind of robe.", &spiderLink)

--- a/backend/database/seeding/seeder.go
+++ b/backend/database/seeding/seeder.go
@@ -184,6 +184,18 @@ func (seed Seeder) ApplyTo(db *database.Connection) error {
 	return err
 }
 
+func (seed Seeder) CategoryForFinding(finding models.Finding) string {
+	if finding.CategoryID == nil {
+		return ""
+	}
+	for _, row := range seed.FindingCategories {
+		if row.ID == *finding.CategoryID {
+			return row.Category
+		}
+	}
+	return ""
+}
+
 func (seed Seeder) EvidenceIDsForFinding(finding models.Finding) []int64 {
 	rtn := make([]int64, 0)
 	for _, row := range seed.EviFindingsMap {

--- a/backend/database/seeding/seeder.go
+++ b/backend/database/seeding/seeder.go
@@ -145,7 +145,7 @@ func (seed Seeder) ApplyTo(db *database.Connection) error {
 				"operation_id":    seed.Findings[i].OperationID,
 				"ready_to_report": seed.Findings[i].ReadyToReport,
 				"ticket_link":     seed.Findings[i].TicketLink,
-				"category":        seed.Findings[i].Category,
+				"category_id":     seed.Findings[i].CategoryID,
 				"title":           seed.Findings[i].Title,
 				"description":     seed.Findings[i].Description,
 				"created_at":      seed.Findings[i].CreatedAt,

--- a/backend/integration/authorization_test.go
+++ b/backend/integration/authorization_test.go
@@ -20,13 +20,13 @@ func TestUserAuthorization(t *testing.T) {
 	a.Get("/web/operations").AsUser(bob).Do().ExpectJSON(`[]`)
 
 	// Ensure bob cannot create findings/evidence under alice's operation
-	a.Post("/web/operations/alice/findings").WithJSONBody(`{"title": "finding", "category": "OPSEC", "description": ""}`).AsUser(bob).Do().ExpectUnauthorized()
+	a.Post("/web/operations/alice/findings").WithJSONBody(`{"title": "finding", "category": "Detection Gap", "description": ""}`).AsUser(bob).Do().ExpectUnauthorized()
 	a.Post("/web/operations/alice/evidence").WithMultipartBody(map[string]string{"description": "evi"}, nil).AsUser(bob).Do().ExpectUnauthorized()
 
 	// Create findings as bob and ensure alice can't see them
 	a.Post("/web/operations").WithJSONBody(`{"name": "Bob's Operation", "slug": "bob"}`).AsUser(bob).Do().ExpectSubsetJSON(`{"name": "Bob's Operation", "status": 0}`)
-	findingUUID1 := a.Post("/web/operations/bob/findings").WithJSONBody(`{"title": "f1", "category": "OPSEC", "description": ""}`).AsUser(bob).Do().ExpectSuccess().ResponseUUID()
-	a.Post("/web/operations/bob/findings").WithJSONBody(`{"title": "e2", "category": "OPSEC", "description": ""}`).AsUser(bob).Do().ExpectSuccess()
+	findingUUID1 := a.Post("/web/operations/bob/findings").WithJSONBody(`{"title": "f1", "category": "Detection Gap", "description": ""}`).AsUser(bob).Do().ExpectSuccess().ResponseUUID()
+	a.Post("/web/operations/bob/findings").WithJSONBody(`{"title": "e2", "category": "Detection Gap", "description": ""}`).AsUser(bob).Do().ExpectSuccess()
 	a.Get("/web/operations/bob/findings").AsUser(alice).Do().ExpectNotFound()
 	a.Get("/web/operations/bob/findings/" + findingUUID1).AsUser(alice).Do().ExpectNotFound()
 	a.Get("/web/operations/alice/findings/" + findingUUID1).AsUser(alice).Do().ExpectNotFound()
@@ -52,7 +52,7 @@ func TestUserAuthorization(t *testing.T) {
 
 	// Ensure alice cannot add bob's evidence to alice's findings
 	findingUUID3 := a.Post("/web/operations/alice/findings").
-		WithJSONBody(`{"title": "Alice's finding", "category": "OPSEC", "description": ""}`).
+		WithJSONBody(`{"title": "Alice's finding", "category": "Detection Gap", "description": ""}`).
 		AsUser(alice).Do().
 		ExpectSubsetJSON(`{"title": "Alice's finding"}`).
 		ResponseUUID()

--- a/backend/integration/evidence_test.go
+++ b/backend/integration/evidence_test.go
@@ -111,8 +111,8 @@ func TestEvidence(t *testing.T) {
 		evidenceUUID1 := a.Post("/web/operations/op/evidence").WithMultipartBody(map[string]string{"description": "Evidence 1"}, nil).Do().ExpectSuccess().ResponseUUID()
 		evidenceUUID2 := a.Post("/web/operations/op/evidence").WithMultipartBody(map[string]string{"description": "Evidence 2"}, nil).Do().ExpectSuccess().ResponseUUID()
 
-		findingUUID1 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "Finding 1", "category": "CD", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
-		findingUUID2 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "Finding 2", "category": "CD", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
+		findingUUID1 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "Finding 1", "category": "Network", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
+		findingUUID2 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "Finding 2", "category": "Network", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
 
 		a.Put("/web/operations/op/findings/" + findingUUID1 + "/evidence").WithJSONBody(`{"evidenceToAdd": ["` + evidenceUUID1 + `"], "evidenceToRemove": []}`).Do().ExpectSuccess()
 		a.Put("/web/operations/op/findings/" + findingUUID2 + "/evidence").WithJSONBody(`{"evidenceToAdd": ["` + evidenceUUID2 + `"], "evidenceToRemove": []}`).Do().ExpectSuccess()

--- a/backend/integration/findings_test.go
+++ b/backend/integration/findings_test.go
@@ -21,16 +21,16 @@ func TestFindings(t *testing.T) {
 		a.Post("/web/operations/op/tags").WithJSONBody(`{"name": "two", "colorName": "green"}`).Do().ExpectSuccess()
 		a.Post("/web/operations/op/tags").WithJSONBody(`{"name": "three", "colorName": "blue"}`).Do().ExpectSuccess()
 
-		uuid := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "Finding 1", "category": "CD", "description": "Here is my finding"}`).Do().ExpectStatus(http.StatusCreated).ResponseUUID()
-		a.Get("/web/operations/op/findings").Do().ExpectSubsetJSONArray([]string{`{"uuid": "` + uuid + `", "title": "Finding 1", "category": "CD", "description": "Here is my finding"}`})
+		uuid := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "Finding 1", "category": "Product", "description": "Here is my finding"}`).Do().ExpectStatus(http.StatusCreated).ResponseUUID()
+		a.Get("/web/operations/op/findings").Do().ExpectSubsetJSONArray([]string{`{"uuid": "` + uuid + `", "title": "Finding 1", "category": "Product", "description": "Here is my finding"}`})
 		a.Put("/web/operations/op/findings/" + uuid).WithJSONBody(`{
 			"title": "Updated title", 
-			"category": "PROD", 
+			"category": "Network", 
 			"description": "Updated description",
 			"readyToReport": false,
 			"ticketLink": null
 		}`).Do().ExpectSuccess()
-		a.Get("/web/operations/op/findings").Do().ExpectSubsetJSONArray([]string{`{"uuid": "` + uuid + `", "title": "Updated title", "category": "PROD", "description": "Updated description"}`})
+		a.Get("/web/operations/op/findings").Do().ExpectSubsetJSONArray([]string{`{"uuid": "` + uuid + `", "title": "Updated title", "category": "Network", "description": "Updated description"}`})
 	})
 
 	t.Run("Deleting findings", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestFindings(t *testing.T) {
 		a.DefaultUser = a.NewUser("adefaultuser", "Alice", "DefaultUser")
 
 		a.Post("/web/operations").WithJSONBody(`{"name": "Op 1", "slug": "op"}`).Do().ExpectSuccess()
-		uuid := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "To be deleted...", "category": "CD", "description": ""}`).Do().ExpectStatus(http.StatusCreated).ResponseUUID()
+		uuid := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "To be deleted...", "category": "Enterprise", "description": ""}`).Do().ExpectStatus(http.StatusCreated).ResponseUUID()
 		a.Get("/web/operations/op/findings").Do().ExpectSubsetJSONArray([]string{`{"uuid": "` + uuid + `", "title": "To be deleted..."}`})
 		a.Delete("/web/operations/op/findings/" + uuid).Do().ExpectSuccess()
 		a.Get("/web/operations/op/findings").Do().ExpectJSON("[]")
@@ -50,10 +50,10 @@ func TestFindings(t *testing.T) {
 		bob := a.NewUser("battacker", "Bob", "Attacker")
 
 		a.Post("/web/operations").WithJSONBody(`{"name": "Alice's Operation", "slug": "alice"}`).AsUser(alice).Do().ExpectSuccess()
-		uuid := a.Post("/web/operations/alice/findings").WithJSONBody(`{"title": "Alice's finding", "category": "CD", "description": ""}`).AsUser(alice).Do().ExpectSuccess().ResponseUUID()
+		uuid := a.Post("/web/operations/alice/findings").WithJSONBody(`{"title": "Alice's finding", "category": "Enterprise", "description": ""}`).AsUser(alice).Do().ExpectSuccess().ResponseUUID()
 		a.Put("/web/operations/alice/findings/" + uuid).WithJSONBody(`{
 			"title": "bob was here", 
-			"category": "BOB", 
+			"category": "Enterprise", 
 			"description": "",
 			"readyToReport": false,
 			"ticketLink": null
@@ -61,7 +61,7 @@ func TestFindings(t *testing.T) {
 
 		// Ensure using an operation that bob controlls does not bypass security check
 		a.Post("/web/operations").WithJSONBody(`{"name": "Bob's Operation", "slug": "bob"}`).AsUser(bob).Do().ExpectSuccess()
-		a.Put("/web/operations/bob/findings/" + uuid).WithJSONBody(`{"title": "bob was here", "category": "BOB", "description": "", "readyToReport": false}`).AsUser(bob).Do().ExpectUnauthorized()
+		a.Put("/web/operations/bob/findings/" + uuid).WithJSONBody(`{"title": "bob was here", "category": "Enterprise", "description": "", "readyToReport": false}`).AsUser(bob).Do().ExpectUnauthorized()
 
 		// Ensure finding is unmodified
 		a.Get("/web/operations/alice/findings").AsUser(alice).Do().ExpectSubsetJSONArray([]string{`{"title": "Alice's finding"}`})
@@ -73,7 +73,7 @@ func TestFindings(t *testing.T) {
 		bob := a.NewUser("battacker", "Bob", "Attacker")
 
 		a.Post("/web/operations").WithJSONBody(`{"name": "Alice's Operation", "slug": "alice"}`).AsUser(alice).Do().ExpectSuccess()
-		uuid := a.Post("/web/operations/alice/findings").WithJSONBody(`{"title": "Alice's finding", "category": "CD", "description": ""}`).AsUser(alice).Do().ExpectSuccess().ResponseUUID()
+		uuid := a.Post("/web/operations/alice/findings").WithJSONBody(`{"title": "Alice's finding", "category": "Product", "description": ""}`).AsUser(alice).Do().ExpectSuccess().ResponseUUID()
 		a.Delete("/web/operations/alice/findings/" + uuid).AsUser(bob).Do().ExpectUnauthorized()
 
 		// Ensure using an operation that bob controlls does not bypass security check
@@ -94,7 +94,7 @@ func TestAssociatingEvidenceWithFindings(t *testing.T) {
 	evidenceUUID1 := a.Post("/web/operations/op1/evidence").WithMultipartBody(map[string]string{"description": "evi1"}, nil).Do().ExpectSuccess().ResponseUUID()
 	evidenceUUID2 := a.Post("/web/operations/op1/evidence").WithMultipartBody(map[string]string{"description": "evi2"}, nil).Do().ExpectSuccess().ResponseUUID()
 	evidenceUUID3 := a.Post("/web/operations/op1/evidence").WithMultipartBody(map[string]string{"description": "evi3"}, nil).Do().ExpectSuccess().ResponseUUID()
-	findingUUID := a.Post("/web/operations/op1/findings").WithJSONBody(`{"title": "finding", "category": "CD", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
+	findingUUID := a.Post("/web/operations/op1/findings").WithJSONBody(`{"title": "finding", "category": "Product", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
 
 	// Check adding and removing evidence
 	a.Put("/web/operations/op1/findings/" + findingUUID + "/evidence").WithJSONBody(`{"evidenceToAdd": ["` + evidenceUUID1 + `", "` + evidenceUUID2 + `"], "evidenceToRemove": []}`).Do().ExpectSuccess()
@@ -106,7 +106,7 @@ func TestAssociatingEvidenceWithFindings(t *testing.T) {
 	a.Post("/web/operations").WithJSONBody(`{"name": "op", "slug": "op2"}`).Do().ExpectSubsetJSON(
 		`{"slug": "op2", "name": "op", "status": 0}`,
 	)
-	findingUUID2 := a.Post("/web/operations/op2/findings").WithJSONBody(`{"title": "other finding", "category": "CD", "description": ""}`).Do().ResponseUUID()
+	findingUUID2 := a.Post("/web/operations/op2/findings").WithJSONBody(`{"title": "other finding", "category": "Product", "description": ""}`).Do().ResponseUUID()
 	a.Put("/web/operations/op2/findings/" + findingUUID2 + "/evidence").WithJSONBody(`{"evidenceToAdd": ["` + evidenceUUID1 + `"], "evidenceToRemove": []}`).Do().ExpectUnauthorized()
 }
 
@@ -121,9 +121,9 @@ func TestTaggingFindings(t *testing.T) {
 	evidenceUUID1 := a.Post("/web/operations/op/evidence").WithMultipartBody(map[string]string{"description": "e1", "tagIds": "[1]", "occurredAt": "2019-05-01T10:00:00Z"}, nil).Do().ExpectSuccess().ResponseUUID()
 	evidenceUUID2 := a.Post("/web/operations/op/evidence").WithMultipartBody(map[string]string{"description": "e2", "tagIds": "[2]", "occurredAt": "2019-06-01T10:00:00Z"}, nil).Do().ExpectSuccess().ResponseUUID()
 	evidenceUUID3 := a.Post("/web/operations/op/evidence").WithMultipartBody(map[string]string{"description": "e3", "occurredAt": "2019-07-01T10:00:00Z"}, nil).Do().ExpectSuccess().ResponseUUID()
-	findingUUID1 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "f1", "category": "CD", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
-	findingUUID2 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "f2", "category": "CD", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
-	findingUUID3 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "f3", "category": "CD", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
+	findingUUID1 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "f1", "category": "Network", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
+	findingUUID2 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "f2", "category": "Network", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
+	findingUUID3 := a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "f3", "category": "Network", "description": ""}`).Do().ExpectSuccess().ResponseUUID()
 
 	// Add evidence to findings
 	a.Put("/web/operations/op/findings/" + findingUUID1 + "/evidence").WithJSONBody(`{"evidenceToAdd": ["` + evidenceUUID1 + `", "` + evidenceUUID2 + `"], "evidenceToRemove": []}`).Do().ExpectSuccess()

--- a/backend/integration/helpers.go
+++ b/backend/integration/helpers.go
@@ -39,6 +39,8 @@ type Tester struct {
 func NewTester(t *testing.T) *Tester {
 	db := database.NewTestConnection(t, "integration-test-db")
 
+	doMinimalSeed(db)
+
 	contentStore, err := contentstore.NewDevStore()
 	require.NoError(t, err)
 	commonLogger := logging.SetupStdoutLogging()
@@ -62,6 +64,22 @@ func NewTester(t *testing.T) *Tester {
 		t: t,
 		s: httptest.NewServer(s),
 	}
+}
+
+func doMinimalSeed(db *database.Connection) {
+	commonFindingCategories := []string{
+		"Product",
+		"Network",
+		"Enterprise",
+		"Vendor",
+		"Behavioral",
+		"Detection Gap",
+	}
+	db.BatchInsert("finding_categories", len(commonFindingCategories), func(i int) map[string]interface{} {
+		return map[string]interface{}{
+			"category": commonFindingCategories[i],
+		}
+	})
 }
 
 type UserSession struct {

--- a/backend/integration/operations_test.go
+++ b/backend/integration/operations_test.go
@@ -46,6 +46,6 @@ func TestRequestingNonexistentOperations(t *testing.T) {
 	a.Get("/web/operations/op/evidence/1").Do().ExpectNotFound()
 
 	// Writing operations that don't exist returns unauthorized
-	a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "e1", "category": "CD", "description": ""}`).Do().ExpectUnauthorized()
+	a.Post("/web/operations/op/findings").WithJSONBody(`{"title": "e1", "category": "Vendor", "description": ""}`).Do().ExpectUnauthorized()
 	a.Put("/web/operations/op").WithJSONBody(`{"name": "new name"}`).Do().ExpectUnauthorized()
 }

--- a/backend/migrations/20210408212206-remove-findings-category.sql
+++ b/backend/migrations/20210408212206-remove-findings-category.sql
@@ -1,0 +1,31 @@
+-- +migrate Up
+
+ALTER TABLE `findings` ADD COLUMN `category_id` INT NULL DEFAULT NULL AFTER `ticket_link`;
+ALTER TABLE `findings` ADD CONSTRAINT `fk_category_id__finding_categories_id` FOREIGN KEY (`category_id`) REFERENCES `finding_categories`(id);
+
+INSERT INTO `finding_categories` (`category`) 
+    SELECT DISTINCT `category` FROM `findings` WHERE `category` NOT IN (
+        SELECT `category` FROM `finding_categories`
+    ) AND `category` != ''
+;
+
+UPDATE `findings` SET `category_id` = (
+    SELECT `id` FROM `finding_categories` WHERE `category` = `findings`.`category`
+)
+WHERE `findings`.`category` != ''
+;
+
+ALTER TABLE `findings` DROP COLUMN `category`;
+
+-- +migrate Down
+
+ALTER TABLE `findings` ADD COLUMN `category` varchar(255) NOT NULL DEFAULT '' AFTER `category_id`;
+
+UPDATE `findings` SET `category` = (
+    SELECT `category` FROM `finding_categories` WHERE `id` = `findings`.`category_id`
+)
+WHERE `findings`.`category_ID` IS NOT NULL
+;
+
+ALTER TABLE `findings` DROP CONSTRAINT `fk_category_id__finding_categories_id`;
+ALTER TABLE `findings` DROP COLUMN  `category_id`;

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -27,7 +27,7 @@ type Finding struct {
 	OperationID   int64      `db:"operation_id"`
 	ReadyToReport bool       `db:"ready_to_report"`
 	TicketLink    *string    `db:"ticket_link"`
-	Category      string     `db:"category"`
+	CategoryID    *int64     `db:"category_id"`
 	Title         string     `db:"title"`
 	Description   string     `db:"description"`
 	CreatedAt     time.Time  `db:"created_at"`

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -140,7 +140,7 @@ CREATE TABLE `findings` (
   `operation_id` int NOT NULL,
   `ready_to_report` tinyint(1) NOT NULL DEFAULT '0',
   `ticket_link` varchar(255) DEFAULT NULL,
-  `category` varchar(255) NOT NULL DEFAULT '',
+  `category_id` int DEFAULT NULL,
   `title` varchar(255) NOT NULL,
   `description` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -148,7 +148,9 @@ CREATE TABLE `findings` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `uuid` (`uuid`),
   KEY `operation_id` (`operation_id`),
-  CONSTRAINT `findings_ibfk_1` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`)
+  KEY `fk_category_id__finding_categories_id` (`category_id`),
+  CONSTRAINT `findings_ibfk_1` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`),
+  CONSTRAINT `fk_category_id__finding_categories_id` FOREIGN KEY (`category_id`) REFERENCES `finding_categories` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -321,7 +323,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2021-04-07 21:08:11
+-- Dump completed on 2021-04-08 21:50:37
 -- MySQL dump 10.13  Distrib 8.0.22, for Linux (x86_64)
 --
 -- Host: localhost    Database: migrate_db
@@ -345,7 +347,7 @@ CREATE TABLE `users` (
 
 LOCK TABLES `gorp_migrations` WRITE;
 /*!40000 ALTER TABLE `gorp_migrations` DISABLE KEYS */;
-INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2021-04-07 21:08:07'),('20190708185420-create-operations-table.sql','2021-04-07 21:08:07'),('20190708185427-create-events-table.sql','2021-04-07 21:08:07'),('20190708185432-create-evidence-table.sql','2021-04-07 21:08:07'),('20190708185441-create-evidence-event-map-table.sql','2021-04-07 21:08:07'),('20190716190100-create-user-operation-map-table.sql','2021-04-07 21:08:07'),('20190722193434-create-tags-table.sql','2021-04-07 21:08:07'),('20190722193937-create-tag-event-map.sql','2021-04-07 21:08:07'),('20190909183500-add-short-name-to-users-table.sql','2021-04-07 21:08:07'),('20190909190416-add-short-name-index.sql','2021-04-07 21:08:08'),('20190926205116-evidence-name.sql','2021-04-07 21:08:08'),('20190930173342-add-saved-searches.sql','2021-04-07 21:08:08'),('20191001182541-evidence-tags.sql','2021-04-07 21:08:08'),('20191008005212-add-uuid-to-events-evidence.sql','2021-04-07 21:08:08'),('20191015235306-add-slug-to-operations.sql','2021-04-07 21:08:08'),('20191018172105-modular-auth.sql','2021-04-07 21:08:09'),('20191023170906-codeblock.sql','2021-04-07 21:08:09'),('20191101185207-replace-events-with-findings.sql','2021-04-07 21:08:09'),('20191114211948-add-operation-to-tags.sql','2021-04-07 21:08:09'),('20191205182830-create-api-keys-table.sql','2021-04-07 21:08:09'),('20191213222629-users-with-email.sql','2021-04-07 21:08:09'),('20200103194053-rename-short-name-to-slug.sql','2021-04-07 21:08:09'),('20200104013804-rework-ashirt-auth.sql','2021-04-07 21:08:10'),('20200116070736-add-admin-flag.sql','2021-04-07 21:08:10'),('20200130175541-fix-color-truncation.sql','2021-04-07 21:08:10'),('20200205200208-disable-user-support.sql','2021-04-07 21:08:10'),('20200215015330-optional-user-id.sql','2021-04-07 21:08:10'),('20200221195107-deletable-user.sql','2021-04-07 21:08:10'),('20200303215004-move-last-login.sql','2021-04-07 21:08:10'),('20200306221628-add-explicit-headless.sql','2021-04-07 21:08:10'),('20200331155258-finding-status.sql','2021-04-07 21:08:11'),('20200617193248-case-senitive-apikey.sql','2021-04-07 21:08:11'),('20200928160958-add-totp-secret-to-auth-table.sql','2021-04-07 21:08:11'),('20210401220807-dynamic-categories.sql','2021-04-07 21:08:11');
+INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2021-04-08 21:50:33'),('20190708185420-create-operations-table.sql','2021-04-08 21:50:33'),('20190708185427-create-events-table.sql','2021-04-08 21:50:33'),('20190708185432-create-evidence-table.sql','2021-04-08 21:50:33'),('20190708185441-create-evidence-event-map-table.sql','2021-04-08 21:50:33'),('20190716190100-create-user-operation-map-table.sql','2021-04-08 21:50:33'),('20190722193434-create-tags-table.sql','2021-04-08 21:50:33'),('20190722193937-create-tag-event-map.sql','2021-04-08 21:50:33'),('20190909183500-add-short-name-to-users-table.sql','2021-04-08 21:50:33'),('20190909190416-add-short-name-index.sql','2021-04-08 21:50:33'),('20190926205116-evidence-name.sql','2021-04-08 21:50:33'),('20190930173342-add-saved-searches.sql','2021-04-08 21:50:34'),('20191001182541-evidence-tags.sql','2021-04-08 21:50:34'),('20191008005212-add-uuid-to-events-evidence.sql','2021-04-08 21:50:34'),('20191015235306-add-slug-to-operations.sql','2021-04-08 21:50:34'),('20191018172105-modular-auth.sql','2021-04-08 21:50:34'),('20191023170906-codeblock.sql','2021-04-08 21:50:35'),('20191101185207-replace-events-with-findings.sql','2021-04-08 21:50:35'),('20191114211948-add-operation-to-tags.sql','2021-04-08 21:50:35'),('20191205182830-create-api-keys-table.sql','2021-04-08 21:50:35'),('20191213222629-users-with-email.sql','2021-04-08 21:50:35'),('20200103194053-rename-short-name-to-slug.sql','2021-04-08 21:50:35'),('20200104013804-rework-ashirt-auth.sql','2021-04-08 21:50:35'),('20200116070736-add-admin-flag.sql','2021-04-08 21:50:35'),('20200130175541-fix-color-truncation.sql','2021-04-08 21:50:35'),('20200205200208-disable-user-support.sql','2021-04-08 21:50:35'),('20200215015330-optional-user-id.sql','2021-04-08 21:50:36'),('20200221195107-deletable-user.sql','2021-04-08 21:50:36'),('20200303215004-move-last-login.sql','2021-04-08 21:50:36'),('20200306221628-add-explicit-headless.sql','2021-04-08 21:50:36'),('20200331155258-finding-status.sql','2021-04-08 21:50:36'),('20200617193248-case-senitive-apikey.sql','2021-04-08 21:50:36'),('20200928160958-add-totp-secret-to-auth-table.sql','2021-04-08 21:50:36'),('20210401220807-dynamic-categories.sql','2021-04-08 21:50:36'),('20210408212206-remove-findings-category.sql','2021-04-08 21:50:37');
 /*!40000 ALTER TABLE `gorp_migrations` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -358,4 +360,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2021-04-07 21:08:11
+-- Dump completed on 2021-04-08 21:50:37

--- a/backend/services/create_finding.go
+++ b/backend/services/create_finding.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/theparanoids/ashirt-server/backend"
@@ -39,11 +40,20 @@ func CreateFinding(ctx context.Context, db *database.Connection, i CreateFinding
 		return nil, backend.MissingValueErr("Category")
 	}
 
+	useCategoryID, err := getFindingCategoryID(i.Category, db.Select)
+
+	if err != nil {
+		return nil, backend.WrapError("Unable create finding", err)
+	}
+	if useCategoryID == nil {
+		return nil, backend.BadInputErr(errors.New("no such category"), "Unknown Category")
+	}
+
 	findingUUID := uuid.New().String()
 	_, err = db.Insert("findings", map[string]interface{}{
 		"uuid":         findingUUID,
 		"operation_id": operation.ID,
-		"category":     i.Category,
+		"category_id":  useCategoryID,
 		"title":        i.Title,
 		"description":  i.Description,
 	})

--- a/backend/services/create_finding_test.go
+++ b/backend/services/create_finding_test.go
@@ -19,7 +19,7 @@ func TestCreateFinding(t *testing.T) {
 	op := OpChamberOfSecrets
 	i := services.CreateFindingInput{
 		OperationSlug: op.Slug,
-		Category:      "Garbage",
+		Category:      VendorFindingCategory.Category,
 		Title:         "When Dinosaurs Attack",
 		Description:   "An investigative look into what happens when dinosaurs vandalize neighborhoods like yours",
 	}

--- a/backend/services/list_findings_for_operation.go
+++ b/backend/services/list_findings_for_operation.go
@@ -51,8 +51,7 @@ func ListFindingsForOperation(ctx context.Context, db *database.Connection, i Li
 		"MIN(evidence.occurred_at) AS occurred_from",
 		"MAX(evidence.occurred_at) AS occurred_to",
 		"GROUP_CONCAT(DISTINCT tag_id) AS tag_ids",
-		"finding_categories.category AS finding_category",
-		).
+		"finding_categories.category AS finding_category").
 		From("findings").
 		LeftJoin("evidence_finding_map ON findings.id = finding_id").
 		LeftJoin("evidence ON evidence_id = evidence.id").

--- a/backend/services/list_findings_for_operation.go
+++ b/backend/services/list_findings_for_operation.go
@@ -38,10 +38,11 @@ func ListFindingsForOperation(ctx context.Context, db *database.Connection, i Li
 	whereClause, whereValues := buildListFindingsWhereClause(operation.ID, i.Filters)
 	var findings []struct {
 		models.Finding
-		NumEvidence  int        `db:"num_evidence"`
-		OccurredFrom *time.Time `db:"occurred_from"`
-		OccurredTo   *time.Time `db:"occurred_to"`
-		TagIDs       *string    `db:"tag_ids"`
+		NumEvidence     int        `db:"num_evidence"`
+		OccurredFrom    *time.Time `db:"occurred_from"`
+		OccurredTo      *time.Time `db:"occurred_to"`
+		TagIDs          *string    `db:"tag_ids"`
+		FindingCategory *string    `db:"finding_category"`
 	}
 
 	sb := sq.Select(
@@ -49,11 +50,14 @@ func ListFindingsForOperation(ctx context.Context, db *database.Connection, i Li
 		"COUNT(DISTINCT evidence_finding_map.evidence_id) AS num_evidence",
 		"MIN(evidence.occurred_at) AS occurred_from",
 		"MAX(evidence.occurred_at) AS occurred_to",
-		"GROUP_CONCAT(DISTINCT tag_id) AS tag_ids").
+		"GROUP_CONCAT(DISTINCT tag_id) AS tag_ids",
+		"finding_categories.category AS finding_category",
+		).
 		From("findings").
 		LeftJoin("evidence_finding_map ON findings.id = finding_id").
 		LeftJoin("evidence ON evidence_id = evidence.id").
 		LeftJoin("tag_evidence_map ON tag_evidence_map.evidence_id = evidence_finding_map.evidence_id").
+		LeftJoin("finding_categories ON finding_categories.id = findings.category_id").
 		Where(whereClause, whereValues...).
 		GroupBy("findings.id")
 
@@ -81,9 +85,13 @@ func ListFindingsForOperation(ctx context.Context, db *database.Connection, i Li
 
 	findingsDTO := make([]*dtos.Finding, len(findings))
 	for idx, finding := range findings {
+		realCategory := ""
+		if finding.FindingCategory != nil {
+			realCategory = *finding.FindingCategory
+		}
 		findingsDTO[idx] = &dtos.Finding{
 			UUID:          finding.UUID,
-			Category:      finding.Category,
+			Category:      realCategory,
 			Title:         finding.Title,
 			Description:   finding.Description,
 			OccurredFrom:  finding.OccurredFrom,

--- a/backend/services/list_findings_for_operation_test.go
+++ b/backend/services/list_findings_for_operation_test.go
@@ -38,7 +38,7 @@ func TestListFindingsForOperation(t *testing.T) {
 
 func validateFinding(t *testing.T, expected models.Finding, actual *dtos.Finding) {
 	require.Equal(t, expected.UUID, actual.UUID)
-	require.Equal(t, expected.Category, actual.Category)
+	require.Equal(t, HarryPotterSeedData.CategoryForFinding(expected), actual.Category)
 	require.Equal(t, expected.Title, actual.Title)
 	require.Equal(t, expected.Description, actual.Description)
 	require.Equal(t, expected.ReadyToReport, actual.ReadyToReport)

--- a/backend/services/read_finding.go
+++ b/backend/services/read_finding.go
@@ -44,10 +44,18 @@ func ReadFinding(ctx context.Context, db *database.Connection, i ReadFindingInpu
 		return nil, backend.WrapError("Cannot load tags for evidence", backend.DatabaseErr(err))
 	}
 
+	var realCategory = ""
+	if finding.CategoryID != nil {
+		realCategory, err = getFindingCategory(db, *finding.CategoryID)
+		if err != nil {
+			return nil, backend.WrapError("Cannot load finding category for finding", backend.DatabaseErr(err))
+		}
+	}
+
 	return &dtos.Finding{
 		UUID:          i.FindingUUID,
 		Title:         finding.Title,
-		Category:      finding.Category,
+		Category:      realCategory,
 		Description:   finding.Description,
 		NumEvidence:   len(evidenceIDs),
 		Tags:          allTags,

--- a/backend/services/read_finding_test.go
+++ b/backend/services/read_finding_test.go
@@ -29,7 +29,7 @@ func TestReadFinding(t *testing.T) {
 
 	require.Equal(t, masterFinding.UUID, retrievedFinding.UUID)
 	require.Equal(t, masterFinding.Title, retrievedFinding.Title)
-	require.Equal(t, masterFinding.Category, retrievedFinding.Category)
+	require.Equal(t, HarryPotterSeedData.CategoryForFinding(masterFinding), retrievedFinding.Category)
 	require.Equal(t, masterFinding.Description, retrievedFinding.Description)
 	require.Equal(t, masterFinding.ReadyToReport, retrievedFinding.ReadyToReport)
 	require.Equal(t, masterFinding.TicketLink, retrievedFinding.TicketLink)

--- a/backend/services/seeding_rewrap_test.go
+++ b/backend/services/seeding_rewrap_test.go
@@ -266,3 +266,7 @@ func (seed TestSeedData) EvidenceForOperation(opID int64) []models.Evidence {
 func (seed TestSeedData) TagIDsUsageByDate(opID int64) map[int64][]time.Time {
 	return seed.Seeder.TagIDsUsageByDate(opID)
 }
+
+func (seed TestSeedData) CategoryForFinding(finding models.Finding) string {
+	return seed.Seeder.CategoryForFinding(finding)
+}

--- a/backend/services/service_helpers_internal_test.go
+++ b/backend/services/service_helpers_internal_test.go
@@ -89,7 +89,7 @@ func TestLookupOperationFinding(t *testing.T) {
 	require.Equal(t, goodOp.Findings[0].ID, foundFinding.ID)
 	require.Equal(t, goodOp.Findings[0].UUID, foundFinding.UUID)
 	require.Equal(t, goodOp.Findings[0].OperationID, foundFinding.OperationID)
-	require.Equal(t, goodOp.Findings[0].Category, foundFinding.Category)
+	require.Equal(t, goodOp.Findings[0].CategoryID, foundFinding.CategoryID)
 	require.Equal(t, goodOp.Findings[0].Title, foundFinding.Title)
 	require.Equal(t, goodOp.Findings[0].Description, foundFinding.Description)
 

--- a/backend/services/service_testing_helpers.go
+++ b/backend/services/service_testing_helpers.go
@@ -112,6 +112,7 @@ func setupBasicTestOperation(t *testing.T, db *database.Connection) (mockOperati
 		findingResult, err := CreateFinding(ctx, db, input)
 		require.NoError(t, err)
 
+		categoryID := int64(1) // hard coding for now // TODO:  add to a the finding categories table,  if possible.
 		var findingID int64
 		err = db.Get(&findingID, sq.Select("id").From("findings").Where(sq.Eq{"uuid": findingResult.UUID}))
 		require.NoError(t, err)
@@ -120,7 +121,7 @@ func setupBasicTestOperation(t *testing.T, db *database.Connection) (mockOperati
 			UUID:        findingResult.UUID,
 			Title:       findingResult.Title,
 			Description: findingResult.Description,
-			Category:    input.Category,
+			CategoryID:  &categoryID,
 			OperationID: op.Op.ID,
 		})
 	}

--- a/backend/services/service_testing_helpers.go
+++ b/backend/services/service_testing_helpers.go
@@ -45,6 +45,21 @@ type mockOperation struct {
 // the second operation has a single piece of evidence and finding, to do tests for "such and such does not belong to this operation" branches
 // All wiring still needs to be done by the user
 func setupBasicTestOperation(t *testing.T, db *database.Connection) (mockOperation, mockOperation) {
+
+	commonFindingCategories := []string{
+		"Product",
+		"Network",
+		"Enterprise",
+		"Vendor",
+		"Behavioral",
+		"Detection Gap",
+	}
+	db.BatchInsert("finding_categories", len(commonFindingCategories), func(i int) map[string]interface{} {
+		return map[string]interface{}{
+			"category": commonFindingCategories[i],
+		}
+	})
+
 	goodOp := mockOperation{
 		User:     dtos.User{FirstName: "fn", LastName: "ln", Slug: "sn"},
 		Findings: make([]models.Finding, 0),
@@ -108,11 +123,13 @@ func setupBasicTestOperation(t *testing.T, db *database.Connection) (mockOperati
 	makeEvidence(&badOp, "item5")
 
 	makeFinding := func(op *mockOperation, title string) {
-		input := CreateFindingInput{OperationSlug: op.Op.Slug, Category: "garbage", Title: title, Description: "desc"}
+		input := CreateFindingInput{OperationSlug: op.Op.Slug, Category: "Product", Title: title, Description: "desc"}
 		findingResult, err := CreateFinding(ctx, db, input)
 		require.NoError(t, err)
 
-		categoryID := int64(1) // hard coding for now // TODO:  add to a the finding categories table,  if possible.
+		var categoryID int64
+		err = db.Get(&categoryID, sq.Select("id").From("finding_categories").Where(sq.Eq{"category": commonFindingCategories[0]}))
+		require.NoError(t, err)
 		var findingID int64
 		err = db.Get(&findingID, sq.Select("id").From("findings").Where(sq.Eq{"uuid": findingResult.UUID}))
 		require.NoError(t, err)

--- a/backend/services/update_finding_test.go
+++ b/backend/services/update_finding_test.go
@@ -22,7 +22,7 @@ func TestUpdateFinding(t *testing.T) {
 	input := services.UpdateFindingInput{
 		OperationSlug: masterOp.Slug,
 		FindingUUID:   masterFinding.UUID,
-		Category:      "New Category",
+		Category:      DetectionGapFindingCategory.Category,
 		Title:         "New Title",
 		Description:   "New Description",
 	}


### PR DESCRIPTION
This PR updates findings to drop the `category` column to instead use `category_id`, which will link to the proper category in finding_categories. This keeps the dtos the same, each returning (and expecting) a named Category, and does the translation to/from a category_id on the backend. 

It would better to merge this into the dynamic-findings-categories pr rather than master if possible.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.