### PR TITLE
update classnames to 2.3.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2062,9 +2062,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@types/react-calendar-timeline": "^0.26.3",
     "ace-builds": "^1.4.9",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "date-fns": "^2.18.0",
     "interactjs": "^1.10.11",
     "lodash": "^4.17.21",


### PR DESCRIPTION
A re-work of dependabot's 2.3.1 release, which seemed to be messed up. This is PR is just checking if CI will complain about broken compilation.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.