### PR TITLE
Updating docker-metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2.5.0
+        uses: docker/ghaction-docker-meta@v3.1.0
         with:
           images: ashirt/${{ matrix.service }} # list of Docker images to use as base name for tags
           tags: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Docker meta
         id: docker_meta
-        uses: docker/ghaction-docker-meta@v3.1.0
+        uses: docker/metadata-action@v3.1.0
         with:
           images: ashirt/${{ matrix.service }} # list of Docker images to use as base name for tags
           tags: |


### PR DESCRIPTION
crazy-max/docker-meta is now located at docker/metadata-action. This PR updates the version and moves to the new name.

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt-server/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt-server/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.