### PR TITLE
Fix local auth linking over user email

### DIFF
--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -295,6 +295,15 @@ func (p LocalAuthScheme) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuth
 			return nil, err
 		}
 
+		emailTaken, err := bridge.CheckIfUserEmailTaken(email, true)
+		if err != nil {
+			return nil, err
+		}
+
+		if emailTaken {
+			return nil, backend.BadInputErr(fmt.Errorf("error linking account: email taken"), "An account for this user already exists")
+		}
+
 		encryptedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
 			return nil, backend.WrapError("Unable to encrypt new password", err)


### PR DESCRIPTION
This PR address an issue where a user could delete their local auth account, then re-link by supplying an email address currently used by a user. (an email column exists both as a user column and as an auth column. For auth, it's what you would use to login. For user, it's more of a contact thing)

Note: this same fix has been added to the `js-self-service-recovery` branch,  so a conflict is likely when one of these is merged in.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.