### PR TITLE
dependabot-only workflow 

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,95 @@
+name: Dependabot Workflow
+on:
+  pull_request_target:
+    branches: [ master ]
+
+jobs:
+  gotest:
+    name: Test Backend
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.16
+      id: go
+    - name: Install go tools
+      run: |
+        go get golang.org/x/lint/golint
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2.3.4
+    - name: Build
+      run: go build -v ./...
+    - name: gofmt
+      run: |
+        GOFMTOUT=$(gofmt -l .)
+        if [[ ! -z "${GOFMTOUT}" ]]; then
+          echo "FATAL: gofmt violation(s), please fix"
+          echo $GOFMTOUT
+          exit -1
+        fi
+    - name: go vet
+      run: go vet ./...
+    - name: golint
+      run: golint ./...
+    - name: Test
+      run: |
+        docker run --rm -d -v $(pwd)/backend/schema.sql:/docker-entrypoint-initdb.d/schema.sql -e MYSQL_DATABASE=dev-db -e MYSQL_ROOT_PASSWORD=dev-root-password -e MYSQL_USER=dev-user -e MYSQL_PASSWORD=dev-user-password -p3306:3306 mysql
+        while ! mysqladmin ping -h"127.0.0.1" --silent; do
+          sleep 1
+        done
+        go test -v ./...
+
+  build_push:
+    name: Build and Push
+    needs: [gotest]
+    strategy:
+      matrix:
+        service: [frontend,web,api]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v3.3.0
+        with:
+          images: ashirt/${{ matrix.service }} # list of Docker images to use as base name for tags
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+          flavor: |
+            latest=false
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.4.1
+
+      - name: Build and Push PR
+        if: github.ref != 'refs/heads/master'
+        uses: docker/build-push-action@v2.5.0
+        with:
+          context: .
+          file: Dockerfile.prod.${{ matrix.service }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true # Push with pr-### and sha-xxxxxxx tags
+
+      - name: Build and Push Latest
+        if: github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v2.5.0
+        with:
+          context: .
+          file: Dockerfile.prod.${{ matrix.service }}
+          tags: ${{ steps.docker_meta.outputs.tags }}, ashirt/${{ matrix.service }}:latest #Add latest tag for master
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true


### PR DESCRIPTION
Github actions has restricted access to secrets for untrusted pull requests. There are two options to give dependabot access to secrets detailed here https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

This PR duplicates the existing CI file, changes to `pull_request_target` and limits execution to the dependabot actor. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.