### PR TITLE
Add the ability to invite a user without adding a local auth account

### DIFF
--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -9,6 +9,7 @@ import AuthTable from './auth_table'
 import HeadlessButton from './add_headless'
 import { NavVerticalTabMenu } from 'src/components/tab_vertical_menu'
 import CreateUserButton from "./add_user"
+import InviteuserButton from "./invite_user"
 import OperationsTable from './operations_table'
 import FindingCategoriesTable from "./finding_categories_table"
 import RecoveryMetrics from './recovery_metrics'
@@ -31,6 +32,7 @@ export default (props: RouteComponentProps) => {
               <UserTable {...bus} />
               <HeadlessButton {...bus} />
               <CreateUserButton {...bus} />
+              <InviteuserButton {...bus} />
             </>
           },
           {

--- a/frontend/src/pages/admin/invite_user/index.tsx
+++ b/frontend/src/pages/admin/invite_user/index.tsx
@@ -1,0 +1,28 @@
+// Copyright 2021, Verizon Media
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+import * as React from 'react'
+import Button from 'src/components/button'
+import SettingsSection from 'src/components/settings_section'
+import { InviteUserModal } from 'src/pages/admin_modals'
+
+export default (props: {
+  requestReload?: () => void
+}) => {
+  const [newUser, setNewUser] = React.useState<boolean>(false)
+
+  return (
+    <SettingsSection title="Invite user">
+      <em>
+        Pre-provision accounts for expected users.
+        This will create a new account, and place that account in "recovery" mode. Provide
+        the generated URL to the user and instruct them to link an account once signing in.
+      </em>
+      <Button primary onClick={() => setNewUser(true)}>Invite a User</Button>
+      {newUser && <InviteUserModal onRequestClose={() => {
+        setNewUser(false)
+        props.requestReload && props.requestReload()
+      }} />}
+    </SettingsSection>
+  )
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -37,6 +37,14 @@ export async function adminCreateLocalUser(i: {
   return await ds.adminCreateLocalUser(i)
 }
 
+export async function adminInviteUser(i: {
+  firstName: string,
+  lastName?: string,
+  email: string,
+}) {
+  return await ds.adminInviteUser(i)
+}
+
 export async function logout() {
   await ds.logout()
 }

--- a/frontend/src/services/data_sources/backend/index.ts
+++ b/frontend/src/services/data_sources/backend/index.ts
@@ -72,6 +72,7 @@ export const backendDataSource: DataSource = {
   getRecoveryMetrics: () => req('GET', '/auth/recovery/metrics'),
   adminChangePassword: i => req('PUT', '/auth/local/admin/password', i),
   adminCreateLocalUser: i => req('POST', '/auth/local/admin/register', i),
+  adminInviteUser: i => req('POST', '/auth/recovery/admin/register', i),
   getTotpForUser: ids => req('GET', '/auth/local/totp', ids),
   deleteTotpForUser: ids => req('DELETE', '/auth/local/totp', ids),
 }

--- a/frontend/src/services/data_sources/data_source.ts
+++ b/frontend/src/services/data_sources/data_source.ts
@@ -91,6 +91,7 @@ export interface DataSource {
   getRecoveryMetrics(): Promise<any>
   adminChangePassword(i: { userSlug: string, newPassword: string }): Promise<void>
   adminCreateLocalUser(i: { firstName: string, lastName?: string, email: string }): Promise<dtos.NewUserCreatedByAdmin>,
+  adminInviteUser(i: { firstName: string, lastName?: string, email: string }): Promise<{ code: string }>,
   getTotpForUser(ids: UserSlug): Promise<boolean>
   deleteTotpForUser(ids: UserSlug): Promise<void>
 }


### PR DESCRIPTION
This PR adds the ability to invite users without creating a local auth account. Instead, a user record is created, and a recovery account is generated. This should provide a smoother invite process for primarily non-local authentication instances, as well as just work at all for instances that simply do not include local authentication.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.