### PR TITLE
Reorder buttons, add Operation Overview help text

### DIFF
--- a/frontend/src/pages/operation_overview/index.tsx
+++ b/frontend/src/pages/operation_overview/index.tsx
@@ -17,6 +17,7 @@ import { ReactCalendarItemRendererProps, ReactCalendarGroupRendererProps } from 
 
 // @ts-ignore - npm package @types/react-router-dom needs to be updated (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40131)
 import { useHistory } from 'react-router-dom'
+import SettingsSection from 'src/components/settings_section'
 
 const cx = classnames.bind(require('./stylesheet'))
 
@@ -30,10 +31,30 @@ export default (props: RouteComponentProps<{ slug: string }>) => {
   return (
     <>
       <Button className={cx('back-button')} icon={require('./back.svg')} onClick={() => props.history.goBack()}>Back</Button>
-
+      <SettingsSection title="Operation Overview" width="full-width">
+        <div className={cx('preamble')}>
+          <div >
+            The operation overview gives a birds eye view of evidence being generated over time.
+            This helps give an idea of both progress, as well as the nature of the issues being
+            discoverd.
+          </div>
+          <div className={cx('preamble')}>
+            Tags are grouped by type over a variable slice of time. At the top of the chart are two
+            headings. Clicking into the lower heading will zoom in on that region of time, allowing
+            you to drill down into a particular time to see more precisely when tags were assigned.
+            Clicking on the upper heading will zoom out and provide a bigger picture view.
+          </div>
+        </div>
       {wiredTags.render(tags => {
         if (tags.length == 0) {
-          return <div className={cx('no-content')}>Tags are not being utilized for this operation</div>
+          return (
+            <>
+              <div className={cx('no-content')}>
+                This operation does not have any tagged evidence. Tag existing evidence, or create
+                new evidence with tags to enable this feature.
+              </div>
+            </>
+          )
         }
 
         const { groups, items, firstDate, lastDate, itemRenderer, groupRenderer, timeChangeHandler } = prepTimelineRender(tags)
@@ -71,6 +92,8 @@ export default (props: RouteComponentProps<{ slug: string }>) => {
           </>
         )
       })}
+
+      </SettingsSection>
     </>
   )
 }

--- a/frontend/src/pages/operation_overview/stylesheet.styl
+++ b/frontend/src/pages/operation_overview/stylesheet.styl
@@ -12,3 +12,9 @@
 
   span
     margin-right: 5px
+
+.preamble
+  margin-bottom: 20px
+  
+  div
+    margin-bottom: 10px

--- a/frontend/src/pages/operation_show/layout/toolbar/index.tsx
+++ b/frontend/src/pages/operation_show/layout/toolbar/index.tsx
@@ -67,8 +67,8 @@ export default (props: {
         </div>
 
         <ButtonGroup>
-          <Button onClick={props.onRequestCreateFinding}>Create Finding</Button>
           <Button onClick={props.onRequestCreateEvidence}>Create Evidence</Button>
+          <Button onClick={props.onRequestCreateFinding}>Create Finding</Button>
         </ButtonGroup>
       </div>
       {renderModals(helpModal, builderModal)}


### PR DESCRIPTION
This PR corrects some minor UI issues. Specifically, this reorders buttons to help match natural ordering of work within an operation, and provides some detail on how the operation overview feature works.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.