### PR TITLE
Allow filtering on the evidence timeline by content/evidence type

### DIFF
--- a/backend/helpers/query_parser.go
+++ b/backend/helpers/query_parser.go
@@ -24,6 +24,7 @@ type TimelineFilters struct {
 	UUID             string
 	Text             []string
 	Tags             []string
+	Type             string
 	Operator         string
 	DateRange        *DateRange
 	WithEvidenceUUID string
@@ -89,7 +90,12 @@ func ParseTimelineQuery(query string) (TimelineFilters, error) {
 			if direction == "asc" || direction == "chronological" || direction == "ascending" {
 				timelineFilters.SortAsc = true
 			}
-
+		case "type":
+			if len(v) != 1 {
+				errReason := "Only one evidence type can be specified"
+				return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)
+			}
+			timelineFilters.Type = v[0]
 		default:
 			errReason := fmt.Sprintf("Unknown filter key '%s'", k)
 			return timelineFilters, backend.BadInputErr(errors.New(errReason), errReason)

--- a/backend/services/list_evidence_for_operation.go
+++ b/backend/services/list_evidence_for_operation.go
@@ -115,6 +115,10 @@ func buildListEvidenceWhereClause(sb sq.SelectBuilder, operationID int64, filter
 		sb = sb.Where(eviForOpTagWhereComponent, filters.Tags, len(filters.Tags))
 	}
 
+	if filters.Type != "" {
+		sb = sb.Where(sq.Eq{"evidence.content_type": filters.Type})
+	}
+
 	if filters.Linked != nil {
 		query := "evidence.id"
 		if *filters.Linked {

--- a/frontend/src/components/code_block/index.tsx
+++ b/frontend/src/components/code_block/index.tsx
@@ -29,6 +29,7 @@ export const CodeBlockEditor = (props: {
           value={props.value.language}
           onChange={language => props.onChange({...props.value, language})}
           disabled={props.disabled}
+          nonValueDefault=""
         />
         <Input
           label="Source"

--- a/frontend/src/components/combobox/index.tsx
+++ b/frontend/src/components/combobox/index.tsx
@@ -13,9 +13,12 @@ export type ComboBoxItem<T> = {
   value: T,
 }
 
-function valueToName<T>(value: T, options: Array<ComboBoxItem<T>>): string {
-  for (let option of options) {
+function valueToName<T>(value: T, options: Array<ComboBoxItem<T>>, nonValueDefault?: T): string {
+  for (const option of options) {
     if (option.value === value) return option.name
+  }
+  for (const option of options) {
+    if (option.value === nonValueDefault) return option.name
   }
   throw Error(`Bad value: ${value}`)
 }
@@ -31,6 +34,7 @@ export default function ComboBox<T>(props: {
   onChange: (newValue: T) => void,
   label: string,
   value: T,
+  nonValueDefault?: T,
   className?: string,
   disabled?: boolean,
 }) {
@@ -40,7 +44,7 @@ export default function ComboBox<T>(props: {
   const filteredOptions = filterOptions(props.options, inputValue)
 
   React.useEffect(() => {
-    setInputValue(valueToName(props.value, props.options))
+    setInputValue(valueToName(props.value, props.options, props.nonValueDefault))
   }, [props.value, props.options])
 
   const onSelect = (item: ComboBoxItem<T>) => {
@@ -56,7 +60,7 @@ export default function ComboBox<T>(props: {
 
   const onRequestClose = () => {
     setDropdownVisible(false)
-    setInputValue(valueToName(props.value, props.options))
+    setInputValue(valueToName(props.value, props.options, props.nonValueDefault))
   }
 
   return (

--- a/frontend/src/components/search_query_builder/helpers.ts
+++ b/frontend/src/components/search_query_builder/helpers.ts
@@ -4,7 +4,7 @@
 import * as dateFns from 'date-fns'
 
 import { parseQuery, parseDateRangeString } from 'src/helpers'
-import { Tag } from 'src/global_types'
+import { SupportedEvidenceType, Tag } from 'src/global_types'
 
 export type SearchOptions = {
   text: string,
@@ -12,6 +12,7 @@ export type SearchOptions = {
   uuid?: string,
   tags?: Array<Tag>,
   operator?: string,
+  type?: SupportedEvidenceType,
   dateRange?: [Date, Date],
   hasLink?: boolean,
   withEvidenceUuid?: string,
@@ -33,6 +34,7 @@ export const stringifySearch = (searchOpts: SearchOptions) => {
     searchOpts.dateRange ? `range:${dateToRange(searchOpts.dateRange)}` : '',
     (searchOpts.hasLink != undefined) ? `linked:${searchOpts.hasLink}` : '',
     searchOpts.sortAsc ? 'sort:asc' : '',
+    searchOpts.type ? `type:${searchOpts.type}` : '',
     searchOpts.withEvidenceUuid ? `with-evidence:${searchOpts.withEvidenceUuid}` : '',
     searchOpts.uuid ? `uuid:${searchOpts.uuid}` : '',
   ])
@@ -65,6 +67,9 @@ export const stringToSearch = (searchText: string, allTags: Array<Tag> = []) => 
       if (range) {
         opts.dateRange = range
       }
+    }
+    else if (key == 'type') {
+      opts.type = values[0] as SupportedEvidenceType
     }
     else if (key == 'linked') {
       const interpretedVal = values[0].toLowerCase().trim()

--- a/frontend/src/components/search_query_builder/index.tsx
+++ b/frontend/src/components/search_query_builder/index.tsx
@@ -7,7 +7,7 @@ import * as dateFns from 'date-fns'
 import { useFormField, useModal, renderModals, useWiredData } from 'src/helpers'
 import { listEvidenceCreators } from 'src/services'
 import { SearchOptions } from './helpers'
-import { Evidence, Tag, User, ViewName } from 'src/global_types'
+import { Evidence, SupportedEvidenceType, Tag, User, ViewName } from 'src/global_types'
 import { MaybeDateRange } from 'src/components/date_range_picker/range_picker_helpers'
 
 import Button from 'src/components/button'
@@ -92,6 +92,11 @@ export const FilterFields = (props: {
     value: props.searchOptions.operator,
     onChange: (creator?: string) => props.onChanged({ ...props.searchOptions, operator: creator }),
   }
+  const evidenceTypeProps = {
+    options: supportedEvidenceTypes,
+    value: props.searchOptions.type,
+    onChange: (evidenceType?: SupportedEvidenceType) => props.onChanged({ ...props.searchOptions, type: evidenceType }),
+  }
   const linkedProps = {
     options: supportedLinking,
     value: props.searchOptions.hasLink,
@@ -122,8 +127,13 @@ export const FilterFields = (props: {
       <ComboBox label="Sort Direction" {...sortProps} />
       <ComboBox label="Creator" {...creatorProps} />
 
-      { props.viewName == 'evidence'
-        ? <ComboBox label="Exists in Finding" {...linkedProps} />
+      {props.viewName == 'evidence'
+        ? (
+          <>
+          <ComboBox label="Evidence Type" {...evidenceTypeProps} />
+          <ComboBox label="Exists in Finding" {...linkedProps} />
+          </>
+        )
         : (
           <SplitInputRow label="Includes Evidence (uuid)" className={'linked-evidence-input'}
             inputValue={props.searchOptions.withEvidenceUuid || ''}>
@@ -178,6 +188,15 @@ const supportedLinking: Array<ComboBoxItem<boolean | undefined>> = [
   { name: "Any", value: undefined },
   { name: "Only Included", value: true },
   { name: "Only Non-included", value: false },
+]
+
+const supportedEvidenceTypes: Array<ComboBoxItem<SupportedEvidenceType | undefined>> = [
+  { name: "Any", value: undefined },
+  { name: 'Screenshot', value: 'image' },
+  { name: 'Code Block', value: 'codeblock' },
+  { name: 'Terminal Recording', value: 'terminal-recording' },
+  { name: 'HTTP Request/Response', value: 'http-request-cycle' },
+  { name: 'No Content', value: 'none' },
 ]
 
 const toEnUSDate = (d: Date) => dateFns.format(d, "MMM dd, yyyy")

--- a/frontend/src/pages/operation_show/layout/toolbar/index.tsx
+++ b/frontend/src/pages/operation_show/layout/toolbar/index.tsx
@@ -180,6 +180,15 @@ const SearchHelpModal = (props: {
   </Modal >
 }
 
+const valuesAsCodeSnippets = (vals: Array<string>) => {
+  return vals.map((v, i) => (
+    <span>
+      <CodeSnippet>{v}</CodeSnippet>
+      {(i + 1) == vals.length ? '' : ', '}
+    </span>
+  ))
+}
+
 const HelpText: Array<FilterDetail> = [
   {
     field: 'tag',
@@ -188,7 +197,7 @@ const HelpText: Array<FilterDetail> = [
         <p>
           Filters the result by requiring that the evidence or finding contain each of the
           specified tag fields.
-          </p>
+        </p>
         <p>Multiple <CodeSnippet>tag</CodeSnippet> fields can be specified.</p>
         <p>To easily create this filter, click on the desired tags next to any evidence.</p>
       </>
@@ -200,7 +209,7 @@ const HelpText: Array<FilterDetail> = [
         <p>
           Filters the result by requiring that the evidence or finding was created by a particular
           user.
-          </p>
+        </p>
         <p>Only one <CodeSnippet>operator</CodeSnippet> field can be specified.</p>
         <p>To easily create this filter, click on the desired username next to any evidence.</p>
       </>
@@ -213,11 +222,11 @@ const HelpText: Array<FilterDetail> = [
           Filters the result by requiring that the evidence to have occurred within a particular
           date range. In the findings timeline, this will require that all evidence for a finding
           be contained with the indicated date range. Only one range can be specified.
-            Date Format: <CodeSnippet>yyyy-mm-dd,yyyy-mm-dd</CodeSnippet> where
-            y, m, and d are year, month and day digits respectively.
-            For example: <CodeSnippet>2020-01-01,2020-01-31</CodeSnippet> covers the entire
-            month of January, 2020.
-          </p>
+          Date Format: <CodeSnippet>yyyy-mm-dd,yyyy-mm-dd</CodeSnippet> where
+          y, m, and d are year, month and day digits respectively.
+          For example: <CodeSnippet>2020-01-01,2020-01-31</CodeSnippet> covers the entire
+          month of January, 2020.
+        </p>
         <p>Only one <CodeSnippet>range</CodeSnippet> field can be specified.</p>
         <p>Click on the calendar next to the Timeline Filter to help specify the date.</p>
       </>
@@ -230,17 +239,17 @@ const HelpText: Array<FilterDetail> = [
           Orders the filter in a particular direction. By default, wiith no filter provided,
           results are ordered by "last evidence first", or an effective reverse-chronological
           order.
-          </p>
+        </p>
         <p>
           Possible values:
-            {" "}<CodeSnippet>asc</CodeSnippet>,
-            {" "}<CodeSnippet>ascending</CodeSnippet> or
-            {" "}<CodeSnippet>chronological</CodeSnippet>
+          {" "}<CodeSnippet>asc</CodeSnippet>,
+          {" "}<CodeSnippet>ascending</CodeSnippet> or
+          {" "}<CodeSnippet>chronological</CodeSnippet>
         </p>
         <p>
           Each of the above values will order the results in a "first-evidence-first", or
           chronological order.
-          </p>
+        </p>
         <p>Only one <CodeSnippet>sort</CodeSnippet> field can be specified.</p>
       </>
   },
@@ -250,15 +259,16 @@ const HelpText: Array<FilterDetail> = [
       <>
         <p>
           Filters the result by finding evidence that either has, or has not been attached to a finding.
-          </p>
+        </p>
         <p>
-          Possible values: <CodeSnippet>true</CodeSnippet>, <CodeSnippet>false</CodeSnippet>
+          Possible values: {" "}
+          {valuesAsCodeSnippets(['true', 'false'])}
         </p>
         <p>
           Provide <CodeSnippet>true</CodeSnippet> to require the evidence has been linked
-            with a finding, or <CodeSnippet>false</CodeSnippet> to require evidence that has
-            not been linked with a finding.
-            {" "}<em>This will only have an effect in the Evidence Timeline.</em>
+          with a finding, or <CodeSnippet>false</CodeSnippet> to require evidence that has
+          not been linked with a finding.
+          {" "}<em>This will only have an effect in the Evidence Timeline.</em>
         </p>
         <p>Only one <CodeSnippet>linked</CodeSnippet> field can be specified.</p>
       </>
@@ -269,9 +279,31 @@ const HelpText: Array<FilterDetail> = [
       <>
         <p>
           Filters the result by requiring a fidning to contain a particular piece of evidence.
-            <em>This will only have an effect in the Findings Timeline.</em>
+          <em>This will only have an effect in the Findings Timeline.</em>
         </p>
         <p>Only one <CodeSnippet>with-evidence</CodeSnippet> field can be specified.</p>
+      </>
+  },
+  {
+    field: 'type',
+    description:
+      <>
+        <p>
+          Filters the result by requiring that the evidence have the matching type as the one
+          specified in the filter.
+          {" "}<em>This will only have an effect in the Evidence Timeline.</em>
+        </p>
+        <p>
+          Possible values: {" "}
+          {
+            valuesAsCodeSnippets([
+              'image', 'codeblock', 'terminal-recording', 'http-request-cycle', 'none'
+            ])
+          }
+        </p>
+        <p>
+        </p>
+        <p>Only one <CodeSnippet>type</CodeSnippet> field can be specified.</p>
       </>
   },
   {
@@ -283,7 +315,7 @@ const HelpText: Array<FilterDetail> = [
           This is typically used to share evidence with other users. While it can be specified
           manually, the preferred method is to click the "Copy Permalink" button
           next to the desired evidence, and share the link as needed.
-          </p>
+        </p>
         <p>Only one <CodeSnippet>uuid</CodeSnippet> field can be specified.</p>
       </>
   },


### PR DESCRIPTION
This PR provides an additional filter on the evidence timeline that will restrict the evidence to only a particular category of evidence. Specifically, these are the types you can filter on now:
* Everything / "Any"
* Screenshot
* Code Block
* Terminal Recording
* HTTP Request/Response
* No Content (i.e. uploaded with no type selected/no binary data)