### PR TITLE
Remove Okta library nonce generator 

### DIFF
--- a/backend/authschemes/generate_nonce.go
+++ b/backend/authschemes/generate_nonce.go
@@ -4,9 +4,9 @@ package authschemes
 // Copyright Okta, Inc, 2015-2018
 
 import (
-	"fmt"
-	"encoding/base64"
 	"crypto/rand"
+	"encoding/base64"
+	"fmt"
 )
 
 func GenerateNonce() (string, error) {

--- a/backend/authschemes/generate_nonce.go
+++ b/backend/authschemes/generate_nonce.go
@@ -1,0 +1,20 @@
+package authschemes
+
+// This is copied from: https://github.com/okta/okta-jwt-verifier-golang
+// Copyright Okta, Inc, 2015-2018
+
+import (
+	"fmt"
+	"encoding/base64"
+	"crypto/rand"
+)
+
+func GenerateNonce() (string, error) {
+	nonceBytes := make([]byte, 32)
+	_, err := rand.Read(nonceBytes)
+	if err != nil {
+		return "", fmt.Errorf("could not generate nonce")
+	}
+
+	return base64.URLEncoding.EncodeToString(nonceBytes), nil
+}

--- a/backend/authschemes/oidcauth/oidc_auth.go
+++ b/backend/authschemes/oidcauth/oidc_auth.go
@@ -9,7 +9,6 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
-	"github.com/okta/okta-jwt-verifier-golang/utils"
 	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/authschemes"
 	"github.com/theparanoids/ashirt-server/backend/config"
@@ -113,7 +112,7 @@ func (o OIDCAuth) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge)
 }
 
 func (o OIDCAuth) redirectLogin(w http.ResponseWriter, r *http.Request, bridge authschemes.AShirtAuthBridge, mode string) {
-	nonce, _ := utils.GenerateNonce()
+	nonce, _ := authschemes.GenerateNonce()
 	stateChallenge := csrf.Token(r)
 	bridge.SetAuthSchemeSession(w, r, &preLoginAuthSession{
 		Nonce:              nonce,

--- a/backend/authschemes/oktaauth/okta_auth.go
+++ b/backend/authschemes/oktaauth/okta_auth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
 	verifier "github.com/okta/okta-jwt-verifier-golang"
-	"github.com/okta/okta-jwt-verifier-golang/utils"
 	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/authschemes"
 	"github.com/theparanoids/ashirt-server/backend/config"
@@ -127,7 +126,7 @@ func (okta OktaAuth) makeUserProfile(profile map[string]string) authschemes.User
 }
 
 func (okta OktaAuth) redirectLogin(w http.ResponseWriter, r *http.Request, bridge authschemes.AShirtAuthBridge, mode string) {
-	nonce, _ := utils.GenerateNonce()
+	nonce, _ := authschemes.GenerateNonce()
 	stateChallenge := csrf.Token(r)
 	bridge.SetAuthSchemeSession(w, r, &preLoginAuthSession{
 		Nonce:              nonce,


### PR DESCRIPTION
This removes the okta-jwt-verifier-golang library's `GenerateNonce` with a copy of it, attributed to them. This is done in order to help remove the need to keep this library, and the outdated okta authscheme (in favor of the more modern oidc auth scheme)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.