### PR TITLE
add limit on new user attempts; add extra logging

### DIFF
--- a/backend/authschemes/auth_bridge_test.go
+++ b/backend/authschemes/auth_bridge_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/theparanoids/ashirt-server/backend/authschemes"
 	"github.com/theparanoids/ashirt-server/backend/database"
+	"github.com/theparanoids/ashirt-server/backend/logging"
 	"github.com/theparanoids/ashirt-server/backend/models"
 	"github.com/theparanoids/ashirt-server/backend/session"
 	"github.com/theparanoids/ashirt-server/backend/workers"
@@ -251,6 +252,11 @@ func TestFindUserAuthsByEmail(t *testing.T) {
 
 func initBridgeTest(t *testing.T) (*database.Connection, *session.Store, authschemes.AShirtAuthBridge) {
 	db := database.NewTestConnection(t, "authschemes-test-db")
+
+	if logging.GetSystemLogger() == nil {
+		logging.SetupStdoutLogging()
+	}
+
 	sessionStore, err := session.NewStore(db, session.StoreOptions{SessionDuration: time.Hour, Key: []byte{}})
 	require.NoError(t, err)
 	return db, sessionStore, authschemes.MakeAuthBridge(db, sessionStore, "test", "test-type")


### PR DESCRIPTION
This PR adds some extra logging to the createUser process to help deduce why re-attempts are made. This also limits the number of attempts to 5, to prevent an infinite loop

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.