### PR TITLE
Seed evidence to storage when starting a new dev server

### DIFF
--- a/backend/bin/dev/dev.go
+++ b/backend/bin/dev/dev.go
@@ -18,12 +18,15 @@ import (
 	"github.com/theparanoids/ashirt-server/backend/authschemes/recoveryauth"
 	"github.com/theparanoids/ashirt-server/backend/config"
 	"github.com/theparanoids/ashirt-server/backend/config/confighelpers"
+	"github.com/theparanoids/ashirt-server/backend/contentstore"
 	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/database/seeding"
 	"github.com/theparanoids/ashirt-server/backend/emailservices"
 	"github.com/theparanoids/ashirt-server/backend/logging"
 	"github.com/theparanoids/ashirt-server/backend/server"
 	"github.com/theparanoids/ashirt-server/backend/workers"
+
+	sq "github.com/Masterminds/squirrel"
 )
 
 type SchemeError struct {
@@ -56,12 +59,14 @@ func tryRunServer(logger logging.Logger) error {
 		return err
 	}
 
+	seedFiles := false
 	if seeded, err := seeding.IsSeeded(db); !seeded && err == nil {
 		logger.Log("msg", "applying db seeding")
 		err := seeding.HarryPotterSeedData.ApplyTo(db)
 		if err != nil {
 			return err
 		}
+		seedFiles = true
 	}
 
 	contentStore, err := confighelpers.ChooseContentStoreType(config.AllStoreConfig())
@@ -73,6 +78,13 @@ func tryRunServer(logger logging.Logger) error {
 		return err
 	}
 	logger.Log("msg", "Using Storage", "type", contentStore.Name())
+
+	if seedFiles {
+		logger.Log("msg", "Adding files to storage")
+		if contentStore.Name() != "local" {
+			seedEvidenceFiles(db, contentStore, logger)
+		}
+	}
 
 	schemes := []authschemes.AuthScheme{
 		recoveryauth.New(config.RecoveryExpiry()),
@@ -168,5 +180,42 @@ func startEmailServices(db *database.Connection, logger logging.Logger) {
 		emailLogger.Log("msg", "Staring emailer")
 		emailWorker := workers.MakeEmailWorker(db, emailServicer, logging.With(logger, "service", "email-worker"))
 		emailWorker.Start()
+	}
+}
+
+func seedEvidenceFiles(db *database.Connection, dstStore contentstore.Store, logger logging.Logger) {
+	readStore, err := confighelpers.DefaultDevStore()
+	if err != nil {
+		panic("Cannot create temporary devstore for copying evidence")
+	}
+
+	type evidence struct {
+		FullKey  string `db:"full_image_key"`
+		ThumbKey string `db:"thumb_image_key"`
+	}
+	var evidenceData []evidence
+	err = db.Select(&evidenceData, sq.Select(
+		"full_image_key", "thumb_image_key").
+		From("evidence").
+		Where(sq.NotEq{"content_type": "none"}),
+	)
+
+	if err != nil {
+		panic("Cannot fetch evidence")
+	}
+
+	evidenceList := map[string]bool{}
+	for _, evidenceItem := range evidenceData {
+		evidenceList[evidenceItem.FullKey] = true
+		evidenceList[evidenceItem.ThumbKey] = true
+	}
+
+	for k := range evidenceList {
+		_, foundErr := dstStore.Read(k)
+		if foundErr != nil {
+			logger.Log("msg", "Moving content", "key", k)
+			data, _ := readStore.Read(k)
+			dstStore.UploadWithName(k, data)
+		}
 	}
 }

--- a/backend/contentstore/devstore.go
+++ b/backend/contentstore/devstore.go
@@ -4,6 +4,7 @@
 package contentstore
 
 import (
+	"fmt"
 	"bufio"
 	"io"
 	"os"
@@ -42,6 +43,11 @@ func (d *DevStore) Upload(data io.Reader) (string, error) {
 		return "", backend.WrapError("Unable upload to DevStore", err)
 	}
 	return path.Base(file.Name()), nil
+}
+
+// UploadWithName is unsupported for the devstore.
+func (d *DevStore) UploadWithName(key string, data io.Reader) error {
+	return fmt.Errorf("UploadWithName is Unsupported")
 }
 
 func (d *DevStore) Read(key string) (io.Reader, error) {

--- a/backend/contentstore/gcpstore.go
+++ b/backend/contentstore/gcpstore.go
@@ -38,25 +38,26 @@ func NewGCPStore(bucketName string) (*GCPStore, error) {
 func (s *GCPStore) Upload(data io.Reader) (string, error) {
 	key := uuid.New().String()
 
+	err := s.UploadWithName(key, data)
+
+	return key, err
+}
+
+// UploadWithName is a test/dev helper that places a file on Google Cloud with a given name
+// This is not intended for general use.
+func (s *GCPStore) UploadWithName(key string, data io.Reader) error {
 	ctx := context.Background()
 	wc := s.bucketAccess.Object(key).NewWriter(ctx)
 
 	if _, err := io.Copy(wc, data); err != nil {
-		return key, backend.WrapError("Upload to gcp failed", err)
+		return backend.WrapError("Upload to gcp failed", err)
 	}
 
 	if err := wc.Close(); err != nil {
-		return key, backend.WrapError("Unable to close gcp writer", err)
+		return backend.WrapError("Unable to close gcp writer", err)
 	}
 
-	// TODO: figure out how to properly do ACL for gcp
-	// acl := s.bucketAccess.Object(key).ACL()
-	// err := acl.Set(ctx, storage., storage.ScopeFullControl)
-	// if err != nil {
-	// 	return key, backend.WrapError("Unable to set GCP ACLs", err)
-	// }
-
-	return key, nil
+	return nil
 }
 
 // Read retrieves the indicated file from Google Cloud

--- a/backend/contentstore/memstore.go
+++ b/backend/contentstore/memstore.go
@@ -46,7 +46,6 @@ func (d *MemStore) Upload(data io.Reader) (key string, err error) {
 // can allow for re-writing/replacing data if names are not unique
 //
 // Note: to avoid overwriting random keys, DO NOT use uuids as they key
-// Note 2: This is NOT part of the standard ContentStore interface
 func (d *MemStore) UploadWithName(key string, data io.Reader) error {
 	b, err := io.ReadAll(data)
 	if err != nil {

--- a/backend/contentstore/s3store.go
+++ b/backend/contentstore/s3store.go
@@ -36,6 +36,14 @@ func NewS3Store(bucketName string, region string) (*S3Store, error) {
 func (s *S3Store) Upload(data io.Reader) (string, error) {
 	key := uuid.New().String()
 
+	err := s.UploadWithName(key, data)
+
+	return key, err
+}
+
+// UploadWithName is a test/dev helper that places a file on S3 with a given name
+// This is not intended for general use.
+func (s *S3Store) UploadWithName(key string, data io.Reader) error {
 	_, err := s.s3Client.PutObject(&s3.PutObjectInput{
 		ACL:    aws.String("bucket-owner-full-control"),
 		Body:   aws.ReadSeekCloser(data),
@@ -44,10 +52,10 @@ func (s *S3Store) Upload(data io.Reader) (string, error) {
 	})
 
 	if err != nil {
-		return key, backend.WrapError("Upload to s3 failed", err)
+		return backend.WrapError("Upload to s3 failed", err)
 	}
 
-	return key, nil
+	return nil
 }
 
 // Read retrieves the indicated file from Amazon S3

--- a/backend/contentstore/store.go
+++ b/backend/contentstore/store.go
@@ -12,9 +12,13 @@ import (
 // Upload stores the provided file/bytes into the storage service, returning the location of that
 // file or any error that may have occurred
 //
+// Note that UploadWithName is only intended for development and testing. This should not be used
+// directly.
+//
 // Read retrieves the raw bytes from the storage service, given a key obtained by Upload
 type Store interface {
 	Upload(data io.Reader) (string, error)
+	UploadWithName(key string, data io.Reader) error
 	Read(key string) (io.Reader, error)
 	Delete(key string) error
 	Name() string


### PR DESCRIPTION
This PR allows for seeding files normally stored on the backend to the intended file store. This has been tested with GCP and memory stores. Devstore is omitted here, as there's no work to be done in that case. S3 store _should_ work, but is untested.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.