### PR TITLE
Support Paginated tags on operation edit

### DIFF
--- a/frontend/src/pages/operation_edit/tag_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/tag_editor/index.tsx
@@ -2,6 +2,7 @@
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
+import classnames from 'classnames/bind'
 import { chunk } from 'lodash'
 import { TagWithUsage } from 'src/global_types'
 import { useWiredData, useModal, renderModals } from 'src/helpers'
@@ -17,6 +18,8 @@ import { DeleteTagModal, EditTagModal } from './modals'
 
 // @ts-ignore - npm package @types/react-router-dom needs to be updated (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40131)
 import { useHistory } from 'react-router-dom'
+
+const cx = classnames.bind(require('./stylesheet'))
 
 type compareableFunc = (l: unknown, r: unknown) => number
 

--- a/frontend/src/pages/operation_edit/tag_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/tag_editor/index.tsx
@@ -14,9 +14,9 @@ import { useWiredData, useModal, renderModals } from 'src/helpers'
 // @ts-ignore - npm package @types/react-router-dom needs to be updated (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40131)
 import { useHistory } from 'react-router-dom'
 
-type compareableFunc = (l: any, r: any) => number
+type compareableFunc = (l: unknown, r: unknown) => number
 
-const sortNone: compareableFunc = (a: any, b: any) => 0
+const sortNone: compareableFunc = (a: unknown, b: unknown) => 0
 const sortNums: compareableFunc = (a: TagWithUsage, b: TagWithUsage) => a.evidenceCount - b.evidenceCount
 const sortTags: compareableFunc = (a: TagWithUsage, b: TagWithUsage) => a.name.localeCompare(b.name)
 

--- a/frontend/src/pages/operation_edit/tag_editor/stylesheet.styl
+++ b/frontend/src/pages/operation_edit/tag_editor/stylesheet.styl
@@ -1,0 +1,3 @@
+
+.table
+  margin-bottom: 10px


### PR DESCRIPTION
This PR adds pagination and filtering to the operation tags page. Pagination has been limited to 10 items per page. Filtering will search for all tags that have that substring in their name (this is a case insensitive filtering). Sorting columns is also remains an option.

When applied, the list of tags is transformed in this order:
1. Filtering removes non-relevant tags
2. Tags are sorted
3. Current page is rendered

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.