### PR TITLE
Bump node to 16.14

### DIFF
--- a/Dockerfile.dev.frontend
+++ b/Dockerfile.dev.frontend
@@ -1,4 +1,4 @@
-FROM node:14.14-alpine
+FROM node:16.14-alpine
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile.prod.frontend
+++ b/Dockerfile.prod.frontend
@@ -7,7 +7,7 @@ COPY backend backend
 RUN go run ./backend/dtos/gentypes > dtos.ts
 
 
-FROM node:14.14-alpine AS build
+FROM node:16.14-alpine AS build
 
 RUN mkdir /build
 WORKDIR /build


### PR DESCRIPTION
This is the most recent LTS release. 14.14 is still supported but we
should make sure that we keep these modern.

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt-server/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt-server/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.