### PR TITLE
Bump go to 1.17

### DIFF
--- a/Dockerfile.dev.backend
+++ b/Dockerfile.dev.backend
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine
+FROM golang:1.17-alpine
 
 RUN apk add --no-cache git inotify-tools g++ && \
     rm -rf /var/cache/apk/* && \

--- a/Dockerfile.prod.api
+++ b/Dockerfile.prod.api
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS build
+FROM golang:1.17-alpine AS build
 
 RUN apk add --no-cache git && \
     rm -rf /var/cache/apk/*

--- a/Dockerfile.prod.frontend
+++ b/Dockerfile.prod.frontend
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS dtos
+FROM golang:1.17-alpine AS dtos
 
 RUN mkdir /build
 WORKDIR /build

--- a/Dockerfile.prod.web
+++ b/Dockerfile.prod.web
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS build
+FROM golang:1.17-alpine AS build
 
 RUN apk add --no-cache git && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
This brings the Go version to the newest current version. We've already
bumped the mod file and this will cause it to actually build and use the
1.17 runtime. 1.18 is just around the corner and we should make sure we
bump up to that when it is released.

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt-server/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt-server/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.