### PR TITLE
remove access to operations via ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-all: test-backend test-frontend
 
 .PHONY: test-backend
 test-backend:
-	cd backend && go test ./...
+	cd backend && go vet ./... && go test ./...
 
 .PHONY: test-frontend
 test-frontend:

--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -44,10 +44,6 @@ type Operation struct {
 	Name     string                 `json:"name"`
 	NumUsers int                    `json:"numUsers"`
 	Status   models.OperationStatus `json:"status"`
-
-	// ID is only used in list operations for the API since the screenshot client still expects int64 ids.
-	// Once the screenshot client is updated this line can be removed
-	ID int64 `json:"id"`
 }
 
 type Query struct {

--- a/backend/integration/api_test.go
+++ b/backend/integration/api_test.go
@@ -40,7 +40,7 @@ func TestAPI(t *testing.T) {
 		aliceKey := a.APIKeyForUser(alice)
 
 		a.Post("/web/operations").WithJSONBody(`{"name": "Op 1", "slug": "op1"}`).AsUser(alice).Do().ExpectSuccess()
-		evidenceUUID1 := a.Post("/api/operations/1/evidence").WithAPIKey(aliceKey).WithMultipartBody(sampleEvidenceBody, nil).Do().ExpectStatus(http.StatusCreated).ResponseUUID()
+		evidenceUUID1 := a.Post("/api/operations/op1/evidence").WithAPIKey(aliceKey).WithMultipartBody(sampleEvidenceBody, nil).Do().ExpectStatus(http.StatusCreated).ResponseUUID()
 		a.Get("/web/operations/op1/evidence").AsUser(alice).Do().ExpectSubsetJSONArray([]string{
 			`{"uuid": "` + evidenceUUID1 + `", "description": "evi1", "occurredAt": "2019-07-29T23:12:45Z"}`,
 		})

--- a/backend/integration/api_test.go
+++ b/backend/integration/api_test.go
@@ -34,23 +34,6 @@ func TestAPI(t *testing.T) {
 		a.Get("/api/operations").WithAPIKey(bobKey).Do().ExpectSubsetJSONArray([]string{`{"slug": "bob-op"}`})
 	})
 
-	t.Run("Reading operations from API", func(t *testing.T) {
-		a := integration.NewTester(t)
-		alice := a.NewUser("adefaultuser", "Alice", "DefaultUser")
-		bob := a.NewUser("bsnooper", "Bob", "Snooper")
-		aliceKey := a.APIKeyForUser(alice)
-		bobKey := a.APIKeyForUser(bob)
-
-		a.Post("/web/operations").WithJSONBody(`{"name": "Alice Op", "slug": "alice-op"}`).AsUser(alice).Do().ExpectSuccess()
-		a.Post("/web/operations").WithJSONBody(`{"name": "Bob Op", "slug": "bob-op"}`).AsUser(bob).Do().ExpectSuccess()
-
-		a.Get("/api/operations/1").WithAPIKey(aliceKey).Do().ExpectSubsetJSON(`{"slug": "alice-op"}`)
-		a.Get("/api/operations/2").WithAPIKey(bobKey).Do().ExpectSubsetJSON(`{"slug": "bob-op"}`)
-
-		// Ensure bob cannot read Alice's operation
-		a.Get("/api/operations/1").WithAPIKey(bobKey).Do().ExpectNotFound()
-	})
-
 	t.Run("Creating Evidence from API", func(t *testing.T) {
 		a := integration.NewTester(t)
 		alice := a.NewUser("adefaultuser", "Alice", "DefaultUser")

--- a/backend/integration/evidence_test.go
+++ b/backend/integration/evidence_test.go
@@ -312,7 +312,7 @@ func getOpsIDs(a *integration.Tester, ops *[]dtos.Operation) {
 	for idx, op := range *ops {
 		for _, apiOp := range temp {
 			if apiOp.Slug == op.Slug {
-				(*ops)[idx].ID = apiOp.ID
+				(*ops)[idx].Slug = apiOp.Slug
 				break
 			}
 		}

--- a/backend/services/add_evidence_to_finding_internal_test.go
+++ b/backend/services/add_evidence_to_finding_internal_test.go
@@ -33,15 +33,15 @@ func getEvidenceIDs(t *testing.T, db *database.Connection, findingID int64) []in
 func testBatchAddEvidence(t *testing.T, db *database.Connection, goodOp, badOp mockOperation) {
 	findingID := goodOp.Findings[1].ID
 	initialEviIDs := getEvidenceIDs(t, db, findingID)
-	err := batchAddEvidenceToFinding(db, []string{}, goodOp.Op.ID, findingID)
+	err := batchAddEvidenceToFinding(db, []string{}, goodOp.ID, findingID)
 	require.NoError(t, err)
 	idsAfterEmptyAdd := getEvidenceIDs(t, db, findingID)
 	require.Equal(t, initialEviIDs, idsAfterEmptyAdd)
 
-	err = batchAddEvidenceToFinding(db, []string{badOp.Evidence[0].UUID}, goodOp.Op.ID, findingID)
+	err = batchAddEvidenceToFinding(db, []string{badOp.Evidence[0].UUID}, goodOp.ID, findingID)
 	require.NotNil(t, err)
 
-	err = batchAddEvidenceToFinding(db, []string{goodOp.Evidence[0].UUID}, goodOp.Op.ID, findingID)
+	err = batchAddEvidenceToFinding(db, []string{goodOp.Evidence[0].UUID}, goodOp.ID, findingID)
 	require.NoError(t, err)
 	idsAfterSingleAdd := getEvidenceIDs(t, db, findingID)
 	require.Equal(t, 1, len(idsAfterSingleAdd))

--- a/backend/services/list_operations_for_admin.go
+++ b/backend/services/list_operations_for_admin.go
@@ -17,5 +17,17 @@ func ListOperationsForAdmin(ctx context.Context, db *database.Connection) ([]*dt
 	if err := isAdmin(ctx); err != nil {
 		return nil, backend.UnauthorizedReadErr(err)
 	}
-	return listAllOperations(db)
+	ops, err := listAllOperations(db)
+
+	if err != nil {
+		return nil, err
+	}
+
+	fixedOps := make([]*dtos.Operation, len(ops))
+
+	for i, v := range ops {
+		fixedOps[i] = v.Op
+	}
+
+	return fixedOps, nil
 }

--- a/backend/services/list_operations_for_admin_test.go
+++ b/backend/services/list_operations_for_admin_test.go
@@ -26,7 +26,7 @@ func TestListOperationsForAdmin(t *testing.T) {
 	for _, op := range ops {
 		var expected *models.Operation = nil
 		for _, fOp := range fullOps {
-			if fOp.ID == op.ID {
+			if fOp.Slug == op.Slug {
 				expected = &fOp
 				break
 			}

--- a/backend/services/list_operations_test.go
+++ b/backend/services/list_operations_test.go
@@ -27,7 +27,7 @@ func TestListOperations(t *testing.T) {
 	for _, op := range ops {
 		var expected *models.Operation = nil
 		for _, fOp := range fullOps {
-			if fOp.ID == op.ID {
+			if fOp.Slug == op.Slug {
 				expected = &fOp
 				break
 			}

--- a/backend/services/service_testing_helpers.go
+++ b/backend/services/service_testing_helpers.go
@@ -93,7 +93,6 @@ func setupBasicTestOperation(t *testing.T, db *database.Connection) (mockOperati
 		return op, opID
 	}
 
-
 	goodOp.Op, goodOp.ID = makeOp("goodOp", "Good Operation")
 	badOp.Op, badOp.ID = makeOp("badOp", "Bad Operation")
 


### PR DESCRIPTION
This PR removes the outdated code and endpoints to access operations by ID (instead of by slug).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.