### PR TITLE
Support importing/exporting default tags

### DIFF
--- a/backend/server/web.go
+++ b/backend/server/web.go
@@ -642,6 +642,18 @@ func bindWebRoutes(r *mux.Router, db *database.Connection, contentStore contents
 		return services.CreateDefaultTag(r.Context(), db, i)
 	}))
 
+	route(r, "POST", "/admin/merge/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
+		var tags []services.CreateDefaultTagInput
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(body, &tags); err != nil {
+			return nil, err
+		}
+		return nil, services.MergeDefaultTags(r.Context(), db, tags)
+	}))
+
 	route(r, "PUT", "/admin/tags/{tag_id}", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		i := services.UpdateDefaultTagInput{

--- a/backend/services/create_tag.go
+++ b/backend/services/create_tag.go
@@ -86,7 +86,7 @@ func MergeDefaultTags(ctx context.Context, db *database.Connection, i []CreateDe
 	currentTagNames := make([]string, 0, len(i))
 
 	for _, t := range i {
-		if listContainsString(currentTagNames, t.Name) != -1 {
+		if listContainsString(currentTagNames, t.Name) != -1 || t.Name == ""{
 			continue // no need to re-process a tag if we've dealt with it -- just use the first instance
 		} else {
 			currentTagNames = append(currentTagNames, t.Name)

--- a/frontend/src/components/code_block/index.tsx
+++ b/frontend/src/components/code_block/index.tsx
@@ -74,8 +74,10 @@ export const CodeBlockViewer = (props: {
 
 export const SourcelessCodeblock = (props: {
   code: string,
-  language: string | null,
+  language: string | null
   className?: string
+  editable?: boolean
+  onChange?: (newValue: string) => void,
 }) => {
   const AceEditor = useAsyncComponent(importAceEditorAsync)
 
@@ -83,9 +85,10 @@ export const SourcelessCodeblock = (props: {
     <div className={cx('code-viewer', props.className)}>
       <div className={cx('ace', 'no-source')}>
         <AceEditor
-          readOnly
+          readOnly={props.editable ? false : true}
           mode={props.language || ''}
           value={props.code}
+          onChange={props.onChange}
         />
       </div>
     </div>

--- a/frontend/src/helpers/is_error.ts
+++ b/frontend/src/helpers/is_error.ts
@@ -1,0 +1,7 @@
+export function isError(error: unknown): error is Error {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    typeof (error as Error).message === "string"
+  )
+}

--- a/frontend/src/pages/admin/default_tag_editor/index.tsx
+++ b/frontend/src/pages/admin/default_tag_editor/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020, Verizon Media
+// Copyright 2022, Verizon Media
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
@@ -8,8 +8,15 @@ import { useWiredData } from 'src/helpers'
 import { DefaultTagTable } from 'src/components/tag_editor'
 
 export const DefaultTagEditor = (props: {
+  onReload: (listener: () => void) => void
+  offReload: (listener: () => void) => void
 }) => {
   const wiredTags = useWiredData(getDefaultTags)
+
+  React.useEffect(() => {
+    props.onReload(wiredTags.reload)
+    return () => { props.offReload(wiredTags.reload) }
+  })
 
   return (
     <SettingsSection title="Initial Operation Tags">

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -17,6 +17,7 @@ import UserTable from './user_table'
 
 import { BuildReloadBus } from 'src/helpers/reload_bus'
 import { DefaultTagEditor } from './default_tag_editor'
+import { TagPorter } from './tag_porter'
 
 const cx = classnames.bind(require('./stylesheet'))
 
@@ -54,7 +55,8 @@ export default (props: RouteComponentProps) => {
           {
             id: "tags", label: "Tag Management", content: (
               <>
-                <DefaultTagEditor />
+                <DefaultTagEditor {...bus}/>
+                <TagPorter {...bus}/>
               </>
             )
           },

--- a/frontend/src/pages/admin/tag_porter/index.tsx
+++ b/frontend/src/pages/admin/tag_porter/index.tsx
@@ -1,0 +1,163 @@
+// Copyright 2022, Verizon Media
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+import * as React from 'react'
+import classnames from 'classnames/bind'
+import SettingsSection from 'src/components/settings_section'
+import { getDefaultTags, mergeDefaultTags } from 'src/services'
+import { renderModals, useForm, useFormField, useModal, useWiredData } from 'src/helpers'
+import Modal from 'src/components/modal'
+import Button from 'src/components/button'
+import Form from 'src/components/form'
+import { Tag } from 'src/global_types'
+import { SourcelessCodeblock } from 'src/components/code_block'
+import { isError } from 'src/helpers/is_error'
+import { isPlainObject } from 'lodash'
+
+const cx = classnames.bind(require('./stylesheet'))
+
+export const TagPorter = (props: {
+  requestReload: () => void
+  onReload: (listener: () => void) => void
+  offReload: (listener: () => void) => void
+}) => {
+  const wiredTags = useWiredData(getDefaultTags)
+
+  const exportTagsModal = useModal<{ tags: Array<Tag> }>(modalProps => (
+    <ExportModal {...modalProps} />
+  ))
+
+  const importTagsModal = useModal(modalProps => (
+    <ImportModal {...modalProps} requestReload={props.requestReload} />
+  ))
+
+  React.useEffect(() => {
+    props.onReload(wiredTags.reload)
+    return () => { props.offReload(wiredTags.reload) }
+  })
+
+  return (
+    <>
+      <SettingsSection title="Import/Export Default Tags">
+        <em>You can share your default tags with other AShirt users by import or exporting the default tags here.</em>
+        {wiredTags.render(tags => (
+          <>
+            <div className={cx('button-group')}>
+              <Button primary onClick={() => importTagsModal.show({})}>Import</Button>
+              <Button className={cx('export-button')} primary onClick={() => exportTagsModal.show({ tags })}>Export</Button>
+            </div>
+          </>
+        ))}
+      </SettingsSection>
+      {renderModals(exportTagsModal, importTagsModal)}
+    </>
+  )
+}
+
+const ExportModal = (props: {
+  tags: Array<Tag>
+  onRequestClose: () => void,
+}) => {
+  const jsonData = JSON.stringify(props.tags
+    .map(tag => ({
+      name: tag.name,
+      colorName: tag.colorName,
+    })
+    ), null, 2)
+
+  const formComponentProps = useForm({
+    onSuccess: () => { props.onRequestClose() },
+    handleSubmit: async () => {
+      await navigator.clipboard.writeText(jsonData)
+    }
+  })
+
+  return (
+    <Modal title="Export Tags" onRequestClose={props.onRequestClose}>
+      <Form submitText="Copy" cancelText="Close" onCancel={props.onRequestClose} {...formComponentProps}>
+        <p>Copy the below text and paste it into another AShirt instance</p>
+        <SourcelessCodeblock
+          className={cx('codeblock')}
+          code={jsonData}
+          language="json"
+        />
+      </Form>
+    </Modal>
+  )
+}
+
+const ImportModal = (props: {
+  onRequestClose: () => void,
+  requestReload: () => void
+}) => {
+
+  const codeblockField = useFormField<string>("")
+  const formComponentProps = useForm({
+    fields: [codeblockField],
+    onSuccess: () => { props.onRequestClose() },
+    handleSubmit: async () => {
+      try {
+        const parsedJson = JSON.parse(codeblockField.value) as unknown
+        if (!isTagArray(parsedJson)) {
+          throw new SyntaxError()
+        }
+
+        await mergeDefaultTags(parsedJson)
+        props.requestReload()
+        return
+      }
+      catch (err) {
+        if (isError(err)) {
+          if (err instanceof SyntaxError) {
+            throw new Error("Unable to parse data / Unsupported format")
+          }
+          else {
+            throw new Error(err.message)
+          }
+        }
+        else {
+          // this should never really happen, but is helpful in case something throws a non-error
+          throw new Error("Something went wrong")
+        }
+      }
+    }
+  })
+
+  return (
+    <Modal title="Import Tags" onRequestClose={props.onRequestClose}>
+      <Form submitText="Submit" cancelText="Cancel" onCancel={props.onRequestClose} {...formComponentProps}>
+        <p>Enter the serialized tags in the textbox below. Tags will be merged by name.</p>
+        <SourcelessCodeblock
+          className={cx('codeblock')}
+          code={codeblockField.value}
+          editable={true}
+          onChange={codeblockField.onChange}
+          language="json"
+        />
+      </Form>
+    </Modal>
+  )
+}
+
+type UpsertTag = {
+  name: string
+  colorName: string
+}
+
+const isTag = (t: unknown): t is UpsertTag => {
+  if (isPlainObject(t)) {
+    const maybeTag = t as Record<string, string>
+    return (
+      typeof (maybeTag['name']) === 'string' &&
+      typeof (maybeTag['colorName']) === 'string'
+    )
+  }
+  return false
+}
+
+const isTagArray = (t: unknown): t is Array<UpsertTag> => {
+  if (Array.isArray(t) && t.length > 0) {
+    return t.map(isTag).every(x => x === true)
+  }
+  return false
+}

--- a/frontend/src/pages/admin/tag_porter/stylesheet.styl
+++ b/frontend/src/pages/admin/tag_porter/stylesheet.styl
@@ -1,0 +1,6 @@
+
+.codeblock
+  height: 160px
+
+.export-button
+  margin-left: 10px

--- a/frontend/src/services/data_sources/backend/index.ts
+++ b/frontend/src/services/data_sources/backend/index.ts
@@ -70,6 +70,7 @@ export const backendDataSource: DataSource = {
   createDefaultTag: (payload) => req('POST', `/admin/tags`, payload),
   updateDefaultTag: (ids, payload) => req('PUT', `/admin/tags/${ids.tagId}`, payload),
   deleteDefaultTag: (ids) => req('DELETE', `/admin/tags/${ids.tagId}`),
+  mergeDefaultTags: (payload) => req('POST', `/admin/merge/tags`, payload),
 
   // TODO these should go into their respective authschemes:
   createRecoveryCode: ids => req('POST', '/auth/recovery/generate', ids),

--- a/frontend/src/services/data_sources/data_source.ts
+++ b/frontend/src/services/data_sources/data_source.ts
@@ -24,6 +24,11 @@ type UserPayload = {
   email: string,
 }
 
+type TagPayload = {
+  name: string,
+  colorName: string
+}
+
 export interface DataSource {
   listApiKeys(ids?: UserSlug): Promise<Array<dtos.APIKey>>
   createApiKey(ids: UserSlug): Promise<dtos.APIKey>
@@ -81,14 +86,15 @@ export interface DataSource {
 
   listTags(ids: OpSlug): Promise<Array<dtos.TagWithUsage>>
   listTagsByEvidenceDate(ids: OpSlug): Promise<Array<dtos.TagByEvidenceDate>>
-  createTag(ids: OpSlug, payload: { name: string, colorName: string }): Promise<dtos.Tag>
-  updateTag(ids: OpSlug & TagId, payload: { name: string, colorName: string }): Promise<void>
+  createTag(ids: OpSlug, payload: TagPayload): Promise<dtos.Tag>
+  updateTag(ids: OpSlug & TagId, payload: TagPayload): Promise<void>
   deleteTag(ids: OpSlug & TagId): Promise<void>
 
   listDefaultTags(): Promise<Array<dtos.DefaultTag>>
-  createDefaultTag(payload: { name: string, colorName: string }): Promise<dtos.DefaultTag>
-  updateDefaultTag(ids: TagId, payload: { name: string, colorName: string }): Promise<void>
+  createDefaultTag(payload: TagPayload): Promise<dtos.DefaultTag>
+  updateDefaultTag(ids: TagId, payload: TagPayload): Promise<void>
   deleteDefaultTag(ids: TagId): Promise<void>
+  mergeDefaultTags(payload: Array<TagPayload>): Promise<void>
 
   // TODO these should go into their respective authschemes:
   createRecoveryCode(ids: UserSlug): Promise<{ code: string }>

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -77,3 +77,10 @@ export async function updateDefaultTag(i: {
     { name: i.name, colorName: i.colorName },
   )
 }
+
+export async function mergeDefaultTags(i: Array<{
+  name: string,
+  colorName: string,
+}>) {
+  await ds.mergeDefaultTags(i)
+}


### PR DESCRIPTION
This PR adds the ability to share default tags. The sharing format is provided as a readable json format, allowing for hopefully easy editing. Note that this shares _all_ tags and leaves editing up to the end user, for better or worse.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.