### PR TITLE
Give headless users read/write access to all operations (via api)

### DIFF
--- a/backend/database/seeding/helpers.go
+++ b/backend/database/seeding/helpers.go
@@ -37,7 +37,7 @@ func GetInternalClock() clockwork.Clock {
 // except for NeedsReset, which is always false
 func ContextForUser(my models.User, db *database.Connection) context.Context {
 	ctx := context.Background()
-	return middleware.BuildContextForUser(ctx, db, my.ID, my.Admin)
+	return middleware.BuildContextForUser(ctx, db, my.ID, my.Admin, my.Headless)
 }
 
 // IsSeeded does a check against the database to see if any users are registered. if no users are

--- a/backend/database/seeding/test_helpers.go
+++ b/backend/database/seeding/test_helpers.go
@@ -194,6 +194,16 @@ func GetOperations(t *testing.T, db *database.Connection) []models.Operation {
 	return fullOps
 }
 
+func GetOperationsForUser(t *testing.T, db *database.Connection, userId int64) []models.Operation {
+	var fullOps []models.Operation
+	err := db.Select(&fullOps, sq.Select("id", "slug", "name", "status").
+		From("operations").
+		LeftJoin("user_operation_permissions on operation_id = operations.id").
+		Where(sq.Eq{"user_operation_permissions.user_id": userId}))
+	require.NoError(t, err)
+	return fullOps
+}
+
 func GetUserRolesForOperationByOperationID(t *testing.T, db *database.Connection, id int64) []models.UserOperationPermission {
 	var userRoles []models.UserOperationPermission
 	err := db.Select(&userRoles, sq.Select("*").

--- a/backend/policy/operation.go
+++ b/backend/policy/operation.go
@@ -17,6 +17,7 @@ const (
 // Grants permissions based on operation roles
 type Operation struct {
 	UserID           int64
+	IsHeadless       bool
 	OperationRoleMap map[int64]OperationRole
 }
 

--- a/backend/policy/operation.go
+++ b/backend/policy/operation.go
@@ -37,7 +37,7 @@ func (o *Operation) Check(permission Permission) bool {
 	case CanModifyFindingsOfOperation:
 		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite)
 	case CanModifyEvidenceOfOperation:
-		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite)
+		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite) || o.IsHeadless
 	case CanModifyOperation:
 		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite)
 	case CanModifyQueriesOfOperation:
@@ -48,7 +48,7 @@ func (o *Operation) Check(permission Permission) bool {
 	case CanListUsersOfOperation:
 		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite, OperationRoleRead)
 	case CanReadOperation:
-		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite, OperationRoleRead)
+		return o.hasRole(p.OperationID, OperationRoleAdmin, OperationRoleWrite, OperationRoleRead) || o.IsHeadless
 	}
 	return false
 }

--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -73,6 +73,28 @@ func bindAPIRoutes(r *mux.Router, db *database.Connection, contentStore contents
 		return services.CreateEvidence(r.Context(), db, contentStore, i)
 	}))
 
+	route(r, "PUT", "/api/operations/{operation_slug}/evidence/{evidence_uuid}", jsonHandler(func(r *http.Request) (interface{}, error) {
+		dr := dissectFormRequest(r)
+		i := services.UpdateEvidenceInput{
+			EvidenceUUID:  dr.FromURL("evidence_uuid").Required().AsString(),
+			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
+			Description:   dr.FromBody("notes").AsStringPtr(),
+			Content:       dr.FromFile("file"),
+		}
+		tagsToAddJSON := dr.FromBody("tagsToAdd").OrDefault("[]").AsString()
+		tagsToRemoveJSON := dr.FromBody("tagsToRemove").OrDefault("[]").AsString()
+		if dr.Error != nil {
+			return nil, dr.Error
+		}
+		if err := json.Unmarshal([]byte(tagsToAddJSON), &i.TagsToAdd); err != nil {
+			return nil, backend.BadInputErr(err, "tagsToAdd must be a json array of ints")
+		}
+		if err := json.Unmarshal([]byte(tagsToRemoveJSON), &i.TagsToRemove); err != nil {
+			return nil, backend.BadInputErr(err, "tagsToRemove must be a json array of ints")
+		}
+		return nil, services.UpdateEvidence(r.Context(), db, contentStore, i)
+	}))
+
 	route(r, "GET", "/api/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		i := services.ListTagsForOperationInput{

--- a/backend/services/seeding_rewrap_test.go
+++ b/backend/services/seeding_rewrap_test.go
@@ -48,6 +48,7 @@ var getEvidenceByUUID = seeding.GetEvidenceByUUID
 var getFullEvidenceViaSelectBuilder = seeding.GetFullEvidenceViaSelectBuilder
 var getOperationFromSlug = seeding.GetOperationFromSlug
 var getOperations = seeding.GetOperations
+var getOperationsForUser = seeding.GetOperationsForUser
 var getUserRolesForOperationByOperationID = seeding.GetUserRolesForOperationByOperationID
 var getQueryByID = seeding.GetQueryByID
 var getQueriesForOperationID = seeding.GetQueriesForOperationID

--- a/frontend/src/pages/admin/add_headless/index.tsx
+++ b/frontend/src/pages/admin/add_headless/index.tsx
@@ -13,7 +13,7 @@ export default (props: {
 
   return (
     <SettingsSection title="Headless User Creation">
-      <em>Headless users cannot login as regular users, but can access services via API keys.</em>
+      <em>Headless users cannot login as regular users, but can access services via API keys. Headless users are allowed read/write access to all operations.</em>
       <Button primary onClick={() => setNewHeadlessUser(true)}>Create New Headless User</Button>
       {newHeadlessUser && <AddHeadlessUserModal onRequestClose={() => {
         setNewHeadlessUser(false)


### PR DESCRIPTION
This PR amends the headless capabilities to allow global operation access for headless users. Once merged, headless users will be able to see and write to all operations. However, they cannot perform any admin related function. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.