### PR TITLE
Allow creation of API key when creating a new headless user

### DIFF
--- a/backend/authschemes/auth_bridge.go
+++ b/backend/authschemes/auth_bridge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/theparanoids/ashirt-server/backend"
 	"github.com/theparanoids/ashirt-server/backend/database"
+	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/logging"
 	"github.com/theparanoids/ashirt-server/backend/models"
 	"github.com/theparanoids/ashirt-server/backend/server/middleware"
@@ -42,7 +43,7 @@ func MakeAuthBridge(db *database.Connection, sessionStore *session.Store, authSc
 
 // CreateNewUser allows new users to be registered into the system, if they do not already exist.
 // Note that slug must be unique
-func (ah AShirtAuthBridge) CreateNewUser(profile UserProfile) (services.CreateUserOutput, error) {
+func (ah AShirtAuthBridge) CreateNewUser(profile UserProfile) (*dtos.CreateUserOutput, error) {
 	return services.CreateUser(ah.db, profile.ToCreateUserInput())
 }
 

--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -160,3 +160,8 @@ type FindingCategory struct {
 type NewUserCreatedByAdmin struct {
 	TemporaryPassword string `json:"temporaryPassword"`
 }
+
+type CreateUserOutput struct {
+	RealSlug string `json:"slug"`
+	UserID   int64  `json:"-"` // don't transmit the userid
+}

--- a/backend/dtos/gentypes/generate_typescript_types.go
+++ b/backend/dtos/gentypes/generate_typescript_types.go
@@ -69,7 +69,10 @@ func gen(dtoStruct interface{}) {
 
 func genFieldDefinition(field reflect.StructField) string {
 	jsonKey := strings.Split(field.Tag.Get("json"), ",")[0]
-	return fmt.Sprintf("  %s: %s,\n", jsonKey, toTypescriptType(field.Type))
+	if jsonKey != "-" {
+		return fmt.Sprintf("  %s: %s,\n", jsonKey, toTypescriptType(field.Type))
+	}
+	return ""
 }
 
 func toTypescriptType(t reflect.Type) string {

--- a/backend/dtos/gentypes/generate_typescript_types.go
+++ b/backend/dtos/gentypes/generate_typescript_types.go
@@ -38,6 +38,7 @@ func main() {
 	gen(dtos.FindingCategory{})
 	gen(dtos.CheckConnection{})
 	gen(dtos.NewUserCreatedByAdmin{})
+	gen(dtos.CreateUserOutput{})
 
 	// Since this file only contains typescript types, webpack doesn't pick up the
 	// changes unless there is some actual executable javascript referenced from

--- a/frontend/src/components/form/index.tsx
+++ b/frontend/src/components/form/index.tsx
@@ -24,6 +24,8 @@ export default (props: {
   submitText?: string,
   cancelText?: string,
   submitDanger?: boolean,
+  disableSubmit?: boolean,
+  disableCancel?: boolean,
 }) => {
   const onCancel = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -42,13 +44,14 @@ export default (props: {
           danger={props.submitDanger}
           className={cx('button')}
           loading={props.loading}
+          disabled={props.disableSubmit}
           children={props.submitText}
         />
       )}
       {props.onCancel && <Button
         onClick={onCancel}
         className={cx('button')}
-        disabled={props.loading}
+        disabled={props.loading || props.disableCancel}
         children={props.cancelText}
       />}
     </form>

--- a/frontend/src/components/modal_form/index.tsx
+++ b/frontend/src/components/modal_form/index.tsx
@@ -17,6 +17,8 @@ export default (props: {
   title: string,
   submitDanger?:boolean,
   cancelText?: string,
+  disableSubmit?: boolean,
+  disableCancel?: boolean,
 }) => (
   <Modal title={props.title} onRequestClose={props.onRequestClose}>
     <Form
@@ -28,6 +30,8 @@ export default (props: {
       onSubmit={props.onSubmit}
       submitText={props.submitText}
       submitDanger={props.submitDanger}
+      disableSubmit={props.disableSubmit}
+      disableCancel={props.disableCancel}
     />
   </Modal>
 )

--- a/frontend/src/components/text_copiers/index.tsx
+++ b/frontend/src/components/text_copiers/index.tsx
@@ -32,7 +32,7 @@ export const CopyTextButton = (props: ButtonStyle & {
 
   return (
     <Tooltip content="Copied!" isOpen={tooltipOpen}>
-      <Button {...props} onClick={onClick} children={props.children} />
+      <Button {...props} onClick={onClick} children={props.children} doNotSubmit/>
     </Tooltip>
   )
 }

--- a/frontend/src/global_types.ts
+++ b/frontend/src/global_types.ts
@@ -139,6 +139,10 @@ export type TagWithUsage = {
   evidenceCount: number,
 }
 
+export type NewUser = {
+  slug: string,
+}
+
 export type User = {
   slug: string,
   firstName: string,

--- a/frontend/src/pages/account_settings/api_keys/index.tsx
+++ b/frontend/src/pages/account_settings/api_keys/index.tsx
@@ -7,14 +7,14 @@ import { format } from 'date-fns'
 
 import Button from 'src/components/button'
 import Form from 'src/components/form'
-import Modal from 'src/components/modal'
 import SettingsSection from 'src/components/settings_section'
 import Table from 'src/components/table'
 import { ApiKey } from 'src/global_types'
-import { InputWithCopyButton } from 'src/components/text_copiers'
 import { UserWithAuth } from 'src/global_types'
-import { getApiKeys, createApiKey, deleteApiKey } from 'src/services'
+import { getApiKeys, createApiKey } from 'src/services'
 import { useWiredData, useForm } from 'src/helpers'
+
+import { NewApiKeyModal, DeleteApiKeyModal } from './modals'
 
 const cx = classnames.bind(require('./stylesheet'))
 
@@ -65,37 +65,7 @@ const GenerateKeyButton = (props: {
   return <>
     <Form submitText="Generate New API Key" {...generateKeyForm} />
     {apiKey && (
-      <Modal title="New API Key" onRequestClose={() => setApiKey(null)}>
-        <div className={cx('new-api-key-modal')}>
-          <p>
-            Below are your seceret and access keys.
-            Once you close this modal, the seceret key will no longer be available.
-          </p>
-          <InputWithCopyButton label="Access Key" value={apiKey.accessKey} />
-          <InputWithCopyButton label="Secret Key" value={apiKey.secretKey || ''} />
-          <Button primary onClick={() => setApiKey(null)}>Close</Button>
-        </div>
-      </Modal>
+      <NewApiKeyModal apiKey={apiKey} onRequestClose={ () => setApiKey(null)} />
     )}
   </>
-}
-
-const DeleteApiKeyModal = (props: {
-  apiKey: ApiKey,
-  userSlug: string,
-  onRequestClose: () => void,
-  onDeleted: () => void,
-}) => {
-  const formComponentProps = useForm({
-    onSuccess: () => { props.onRequestClose(); props.onDeleted() },
-    handleSubmit: () => deleteApiKey({ userSlug: props.userSlug, accessKey: props.apiKey.accessKey }),
-  })
-
-  return (
-    <Modal title="Delete API Key" onRequestClose={props.onRequestClose}>
-      <Form submitText="Delete API Key" cancelText="Close" onCancel={props.onRequestClose} {...formComponentProps}>
-        <p>Are you sure you want to delete this API key?</p>
-      </Form>
-    </Modal>
-  )
 }

--- a/frontend/src/pages/account_settings/api_keys/modals.tsx
+++ b/frontend/src/pages/account_settings/api_keys/modals.tsx
@@ -1,0 +1,64 @@
+// Copyright 2022, Verizon Media
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+import * as React from 'react'
+import classnames from 'classnames/bind'
+
+import { ApiKey } from 'src/global_types'
+import Button from 'src/components/button'
+import Form from 'src/components/form'
+import Modal from "src/components/modal"
+import { InputWithCopyButton } from 'src/components/text_copiers'
+import { useForm } from 'src/helpers'
+import { deleteApiKey } from 'src/services'
+
+const cx = classnames.bind(require('./stylesheet'))
+
+export const NewApiKeyModal = (props: {
+  apiKey: ApiKey,
+  onRequestClose: () => void
+}) => {
+  const { apiKey, onRequestClose } = props
+  return (
+    <Modal title="New API Key" onRequestClose={onRequestClose}>
+      <NewApiKeyModalContents apiKey={props.apiKey}>
+        <Button primary onClick={() => onRequestClose()}>Close</Button>
+      </NewApiKeyModalContents>
+    </Modal>
+  )
+}
+
+export const NewApiKeyModalContents = (props:{
+  apiKey: ApiKey,
+  children?: React.ReactNode
+}) => (
+  <div className={cx('new-api-key-modal')}>
+    <p>
+      Below are your seceret and access keys.
+      Once you close this modal, the seceret key will no longer be available.
+    </p>
+    <InputWithCopyButton label="Access Key" value={props.apiKey.accessKey} />
+    <InputWithCopyButton label="Secret Key" value={props.apiKey.secretKey || ''} />
+    {props.children}
+  </div>
+)
+
+export const DeleteApiKeyModal = (props: {
+  apiKey: ApiKey,
+  userSlug: string,
+  onRequestClose: () => void,
+  onDeleted: () => void,
+}) => {
+  const formComponentProps = useForm({
+    onSuccess: () => { props.onRequestClose(); props.onDeleted() },
+    handleSubmit: () => deleteApiKey({ userSlug: props.userSlug, accessKey: props.apiKey.accessKey }),
+  })
+
+  return (
+    <Modal title="Delete API Key" onRequestClose={props.onRequestClose}>
+      <Form submitText="Delete API Key" cancelText="Close" onCancel={props.onRequestClose} {...formComponentProps}>
+        <p>Are you sure you want to delete this API key?</p>
+      </Form>
+    </Modal>
+  )
+}

--- a/frontend/src/services/api_keys.ts
+++ b/frontend/src/services/api_keys.ts
@@ -10,7 +10,7 @@ export async function createApiKey(i: { userSlug: string }): Promise<ApiKey> {
 }
 
 export async function getApiKeys(i?: { userSlug: string }): Promise<Array<ApiKey>> {
-  const keys = await ds.listApiKeys()
+  const keys = await ds.listApiKeys(i)
   return keys.map(apiKeyFromDto)
 }
 

--- a/frontend/src/services/data_sources/data_source.ts
+++ b/frontend/src/services/data_sources/data_source.ts
@@ -72,7 +72,7 @@ export interface DataSource {
   updateUser(ids: UserSlug, payload: UserPayload): Promise<void>
   deleteUserAuthScheme(ids: UserSlug & { authSchemeName: string }): Promise<void>
   adminListUsers(query: { deleted: boolean, name?: string }): Promise<types.PaginationResult<dtos.UserAdminView>>
-  adminCreateHeadlessUser(payload: UserPayload): Promise<void>
+  adminCreateHeadlessUser(payload: UserPayload): Promise<dtos.CreateUserOutput>
 
   listQueries(ids: OpSlug): Promise<Array<dtos.Query>>
   createQuery(ids: OpSlug, payload: { name: string, query: string, type: 'evidence' | 'findings' }): Promise<void>

--- a/frontend/src/services/user.ts
+++ b/frontend/src/services/user.ts
@@ -1,6 +1,7 @@
 // Copyright 2020, Verizon Media
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
+import { NewUser } from 'src/global_types'
 import { backendDataSource as ds } from './data_sources/backend'
 
 export async function updateUserProfile(i: {
@@ -27,8 +28,8 @@ export async function addHeadlessUser(i: {
   firstName: string,
   lastName: string,
   email: string,
-}): Promise<void> {
-  await ds.adminCreateHeadlessUser(i)
+}): Promise<NewUser> {
+  return ds.adminCreateHeadlessUser(i)
 }
 
 export async function createRecoveryCode(i: {


### PR DESCRIPTION
This PR allows for new headless users to optionally generate an api key when creating the user. There is now a checkbox in the new headless user form (defaulted to checked), that, when checked, will also issue a request to create an api key. 

This is based off of the PR that grants headless users universal access to operations.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.