### PR TITLE
Updating Installation for sql-migrate cli

### DIFF
--- a/Dockerfile.prod.init
+++ b/Dockerfile.prod.init
@@ -1,5 +1,5 @@
 FROM golang
-RUN go get -v github.com/rubenv/sql-migrate/...
+RUN go install github.com/rubenv/sql-migrate/sql-migrate@latest
 COPY backend/ /app/backend/
 WORKDIR /app
 ENTRYPOINT ["sql-migrate", "up", "-config=backend/dbconfig.yml"]


### PR DESCRIPTION
go get -v github.com/rubenv/sql-migrate/... no longer works for installation with modern go.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.