### PR TITLE
Fix an issue where smart combo box would cause problems 

### DIFF
--- a/frontend/src/components/combobox/index.tsx
+++ b/frontend/src/components/combobox/index.tsx
@@ -49,10 +49,6 @@ export default function SmartComboBox<T>(props: {
     standardComboboxStateReducer,
     initialComboBoxState(props.value, props.options, props.nonValueDefault),
   )
-  const { onChange } = props
-  React.useEffect(() => {
-    onChange(cbState.value)
-  }, [cbState, onChange])
 
   return (
     <DumbComboBox
@@ -63,7 +59,12 @@ export default function SmartComboBox<T>(props: {
       value={cbState.value}
       disabled={props.disabled}
       className={props.className}
-      onChange={dispatch}
+      onChange={(v) => {
+        dispatch(v)
+        if( v.type == 'popover-selected') {
+          props.onChange(v.item.value)
+        }
+      }}
     />
   )
 }


### PR DESCRIPTION
This PR corrects an issue where SmartComboBox would continually call useEffect.  This can potentially break any area that used this component, specifically the query builder, which used this feature in many places.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.