### PR TITLE
Add ConnectionProxy

### DIFF
--- a/backend/database/connection_proxy.go
+++ b/backend/database/connection_proxy.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"context"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+// ConnectionProxy provides an interface into the database, using either an underlying connection,
+// or a transaction. This is compatible with both Connection and Transactable types
+type ConnectionProxy interface {
+	Select(modelSlice interface{}, builder sq.SelectBuilder) error
+	Get(model interface{}, builder sq.SelectBuilder) error
+	// Exec(query string, values ...interface{}) error // not consistent between Transactable and Connection
+	Insert(table string, valueMap map[string]interface{}) (int64, error)
+	BatchInsert(tableName string, count int, mapFn func(int) map[string]interface{}, onDuplicates ...interface{}) error
+	Update(builder sq.UpdateBuilder) error
+	Delete(builder sq.DeleteBuilder) error
+	WithTx(ctx context.Context, fn func(tx *Transactable)) error
+}
+
+// _verifyConnectionProxyInterface is a "canary" function that ensures that the expected concrete
+// types to the ConnectionProxy interface properly implement the interface.
+//lint:ignore U1000 This is just to verify the interface -- it should never be called directly anyway
+func _verifyConnectionProxyInterface() {
+	var conn *Connection
+	var tx *Transactable
+	check := func(c ConnectionProxy) {}
+	check(conn)
+	check(tx)
+}


### PR DESCRIPTION
This PR introduces a ConnectionProxy, to act as a proxy to a database connection or transaction. This will enable more composable code, as a single function can be used as part of a direct database connection, or as part of a transaction. This was pulled out of PR #490, which used this feature. In general, we'll want to use this when we create new helpers, and slowly transition existing helpers to use this interface. Actual services will still be handed a connection, and will need to create the transaction themselves, as needed.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.