### PR TITLE
Metadata, Part 3 - Render Evidence metadata

### DIFF
--- a/backend/database/seeding/test_helpers.go
+++ b/backend/database/seeding/test_helpers.go
@@ -172,7 +172,7 @@ func GetEvidenceMetadataByEvidenceID(t *testing.T, db *database.Connection, id i
 	var evidenceMetadata []models.EvidenceMetadata
 	err := db.Select(&evidenceMetadata, sq.Select("*").
 		From("evidence_metadata").
-		Where(sq.Eq{ "evidence_id": id }))
+		Where(sq.Eq{"evidence_id": id}))
 	require.NoError(t, err)
 	return evidenceMetadata
 }

--- a/frontend/src/components/expandable_area/index.tsx
+++ b/frontend/src/components/expandable_area/index.tsx
@@ -1,11 +1,15 @@
+// Copyright 2022, Yahoo Inc.
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
 import * as React from 'react'
 import classnames from 'classnames/bind'
 const cx = classnames.bind(require('./stylesheet'))
 
 export const ExpandableSection = (props: {
-  children: string
-  content: React.ReactNode
+  children: React.ReactNode
+  label: React.ReactNode
   className?: string
+  labelClassName?: string
   initiallyExpanded?: boolean
   onExpanded?: (expanded: boolean)=>void
 }) => {
@@ -18,10 +22,10 @@ export const ExpandableSection = (props: {
         setExpanded(newValue)
         props.onExpanded && props.onExpanded(newValue)
       }}>
-        <section className={cx('expandable-section-label')}>{props.children}</section>
+        <section className={cx('expandable-section-label', props.labelClassName)}>{props.label}</section>
       </div>
       <div className={cx('expandable-content')}>
-        {expanded && props.content}
+        {expanded && props.children}
       </div>
     </section>
   )

--- a/frontend/src/components/http_cycle_viewer/index.tsx
+++ b/frontend/src/components/http_cycle_viewer/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021, Verizon Media
+// Copyright 2022, Yahoo Inc.
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
@@ -106,20 +106,14 @@ const EntryHeadersData = (props: {
 
   return (
     <div className={cx('headers-grouping')}>
-      <ExpandableSection {...expandedAreaProps('request-info')} content={
+      <ExpandableSection {...expandedAreaProps('request-info')} label="Request Info">
         <RequestInfo entry={props.entry} />
-      }>
-        Request Info
       </ExpandableSection>
-      <ExpandableSection {...expandedAreaProps('request-headers')} content={
+      <ExpandableSection {...expandedAreaProps('request-headers')} label="Request Headers">
         <SectionDefintions definitions={formatHeaders(props.entry.request.headers)} />
-      }>
-        Request Headers
       </ExpandableSection>
-      <ExpandableSection {...expandedAreaProps('response-headers')} content={
+      <ExpandableSection {...expandedAreaProps('response-headers')} label="Response Headers">
         <SectionDefintions definitions={formatHeaders(props.entry.response.headers)} />
-      }>
-        Response Headers
       </ExpandableSection>
     </div>
   )

--- a/frontend/src/pages/operation_show/evidence_list/index.tsx
+++ b/frontend/src/pages/operation_show/evidence_list/index.tsx
@@ -9,6 +9,7 @@ import {
   DeleteEvidenceModal,
   ChangeFindingsOfEvidenceModal,
   MoveEvidenceModal,
+  EvidenceMetadataModal,
 } from '../evidence_modals'
 import { Evidence } from 'src/global_types'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
@@ -40,6 +41,9 @@ export default () => {
       setLastEditedUuid(modalProps.evidence.uuid)
       wiredEvidence.reload()
     }} />
+  ))
+  const viewModal = useModal<{ evidence: Evidence }>(modalProps => (
+    <EvidenceMetadataModal {...modalProps} operationSlug={operationSlug} onUpdated={wiredEvidence.reload} />
   ))
   const deleteModal = useModal<{ evidence: Evidence }>(modalProps => (
     <DeleteEvidenceModal {...modalProps} operationSlug={operationSlug} onDeleted={reloadToTop} />
@@ -76,6 +80,7 @@ export default () => {
           extraActions={[
             { label: 'Move', act: evidence => moveModal.show({ evidence }) },
             { label: 'Delete', act: evidence => deleteModal.show({ evidence }) },
+            { label: "Metadata", act: evidence => viewModal.show({ evidence }) },
           ]}
           onQueryUpdate={query => navTo('evidence', query)}
           operationSlug={operationSlug}
@@ -83,7 +88,7 @@ export default () => {
         />
       ))}
 
-      {renderModals(editModal, deleteModal, assignToFindingsModal, moveModal)}
+      {renderModals(editModal, deleteModal, assignToFindingsModal, moveModal, viewModal)}
     </Layout>
   )
 }

--- a/frontend/src/pages/operation_show/evidence_modals/stylesheet.styl
+++ b/frontend/src/pages/operation_show/evidence_modals/stylesheet.styl
@@ -1,3 +1,44 @@
 
 .dropdown
   width: 35%
+
+.view-metadata-root
+  display: flex
+  flex-direction: column
+  gap: 5px
+
+.button-row
+  position: relative
+
+.close-button
+  margin-top: 10px
+
+.metadata-content
+  flex-grow: 1
+  display: inline-block
+  font-weight: normal
+  padding-left: 5px
+  padding-bottom: 5px
+
+.label-not-important
+  color: #777
+
+.content-important
+  background-color: #6c3ec7
+
+.tab-menu
+  margin-bottom: 10px
+  align-items: center
+  justify-content: center
+
+.expandable-section-label-container
+  display: flex
+  justify-content: space-between
+
+.expandable-section-button-group
+  margin-right: 10px
+
+.expandable-section-label
+  white-space: nowrap
+  text-overflow: ellipsis
+  overflow: hidden


### PR DESCRIPTION
This PR adds the ability to view the evidence metadata in the timeline. This also has a hardcoded toggle that will enable web-based metadata editing (currently set to on)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.