### PR TITLE
Js/better service tests

### DIFF
--- a/backend/database/seeding/seeder.go
+++ b/backend/database/seeding/seeder.go
@@ -48,6 +48,11 @@ func (seed Seeder) AllInitialDefaultTagIds() []int64 {
 
 // ApplyTo takes the configured Seeder and writes these values to the database.
 func (seed Seeder) ApplyTo(db *database.Connection) error {
+	if (len(seed.Users) == 0) {
+		logging.GetSystemLogger().Log("msg", "Applying NO seed data")
+		return nil
+	}
+
 	systemLogger := logging.GetSystemLogger()
 	systemLogger.Log("msg", "Applying seed data", "firstUser", seed.Users[0].FirstName)
 	logging.SetSystemLogger(logging.NewNopLogger())

--- a/backend/database/seeding/seeder.go
+++ b/backend/database/seeding/seeder.go
@@ -228,6 +228,14 @@ func (seed Seeder) ApplyTo(db *database.Connection) error {
 	return err
 }
 
+func (seed Seeder) Reset(db *database.Connection) error {
+	err := ClearDB(db)
+	if err != nil {
+		return err
+	}
+	return seed.ApplyTo(db)
+}
+
 func (seed Seeder) CategoryForFinding(finding models.Finding) string {
 	if finding.CategoryID == nil {
 		return ""

--- a/backend/database/seeding/test_helpers.go
+++ b/backend/database/seeding/test_helpers.go
@@ -66,6 +66,39 @@ func InitTestWithOptions(t *testing.T, options TestOptions) *database.Connection
 	return database.NewTestConnectionFromNonStandardMigrationPath(t, *options.DatabaseName, *options.DatabasePath)
 }
 
+// ClearDB empties the database of all values. This leaves behind small residue: IDs are already taken,
+// so, auto-incremented values will use the next value, not re-use values. However, this is easily
+// overcome by specifying what the ID should be -- which is part of each seed anyway.
+// 
+// Note: this should only be done in a testing environment. 
+func ClearDB(db *database.Connection) error {
+	systemLogger := logging.GetSystemLogger()
+	systemLogger.Log("msg", "Clearing Database...")
+	logging.SetSystemLogger(logging.NewNopLogger())
+	defer logging.SetSystemLogger(systemLogger)
+
+	err := db.WithTx(context.Background(), func(tx *database.Transactable) {
+		tx.Delete(sq.Delete("sessions"))
+		tx.Delete(sq.Delete("user_operation_permissions"))
+		tx.Delete(sq.Delete("api_keys"))
+		tx.Delete(sq.Delete("auth_scheme_data"))
+		tx.Delete(sq.Delete("email_queue"))
+		tx.Delete(sq.Delete("tag_evidence_map"))
+		tx.Delete(sq.Delete("tags"))
+		tx.Delete(sq.Delete("default_tags"))
+		tx.Delete(sq.Delete("evidence_finding_map"))
+		tx.Delete(sq.Delete("evidence_metadata"))
+		tx.Delete(sq.Delete("evidence"))
+		tx.Delete(sq.Delete("findings"))
+		tx.Delete(sq.Delete("finding_categories"))
+		tx.Delete(sq.Delete("users"))
+		tx.Delete(sq.Delete("queries"))
+		tx.Delete(sq.Delete("operations"))
+		tx.Delete(sq.Delete("service_workers"))
+	})
+	return err
+}
+
 // SimpleFullContext returns back a context with a proper authenticated policy
 func SimpleFullContext(my models.User) context.Context {
 	ctx := context.Background()

--- a/backend/services/api_key_test.go
+++ b/backend/services/api_key_test.go
@@ -14,23 +14,23 @@ import (
 )
 
 func TestCreateAPIKey(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	normalUser := UserHermione
-	targetUser := UserNeville
-	adminUser := UserDumbledore
-	ctx := contextForUser(normalUser, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserHermione
+		targetUser := UserNeville
+		adminUser := UserDumbledore
+		ctx := contextForUser(normalUser, db)
 
-	// Verify self actions
-	verifyCreateAPIKey(t, false, ctx, db, normalUser.ID, "")
-	verifyCreateAPIKey(t, false, ctx, db, normalUser.ID, normalUser.Slug)
+		// Verify self actions
+		verifyCreateAPIKey(t, false, ctx, db, normalUser.ID, "")
+		verifyCreateAPIKey(t, false, ctx, db, normalUser.ID, normalUser.Slug)
 
-	// verify other-based actions (non-admin)
-	verifyCreateAPIKey(t, true, ctx, db, targetUser.ID, targetUser.Slug)
+		// verify other-based actions (non-admin)
+		verifyCreateAPIKey(t, true, ctx, db, targetUser.ID, targetUser.Slug)
 
-	// verify other-based actions (admin)
-	ctx = contextForUser(adminUser, db)
-	verifyCreateAPIKey(t, false, ctx, db, targetUser.ID, targetUser.Slug)
+		// verify other-based actions (admin)
+		ctx = contextForUser(adminUser, db)
+		verifyCreateAPIKey(t, false, ctx, db, targetUser.ID, targetUser.Slug)
+	})
 }
 
 func verifyCreateAPIKey(t *testing.T, expectError bool, ctx context.Context, db *database.Connection, userID int64, userSlug string) {
@@ -54,47 +54,46 @@ func verifyCreateAPIKey(t *testing.T, expectError bool, ctx context.Context, db 
 }
 
 func TestDeleteAPIKey(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	normalUser := UserRon
-	targetUser := UserHarry
-	adminUser := UserDumbledore
-	ctx := contextForUser(normalUser, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		targetUser := UserHarry
+		adminUser := UserDumbledore
+		ctx := contextForUser(normalUser, db)
 
-	// verify delete api key for other user (as self)
-	verifyDeleteAPIKey(t, true, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
-		UserSlug:  normalUser.Slug,
-		AccessKey: APIKeyHarry1.AccessKey,
-	})
+		// verify delete api key for other user (as self)
+		verifyDeleteAPIKey(t, true, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
+			UserSlug:  normalUser.Slug,
+			AccessKey: APIKeyHarry1.AccessKey,
+		})
 
-	// verify delete api key for other user (as self - alt)
-	verifyDeleteAPIKey(t, true, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
-		AccessKey: APIKeyHarry1.AccessKey,
-	})
+		// verify delete api key for other user (as self - alt)
+		verifyDeleteAPIKey(t, true, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
+			AccessKey: APIKeyHarry1.AccessKey,
+		})
 
-	// verify delete api key for self
-	verifyDeleteAPIKey(t, false, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
-		AccessKey: APIKeyRon1.AccessKey,
-	})
+		// verify delete api key for self
+		verifyDeleteAPIKey(t, false, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
+			AccessKey: APIKeyRon1.AccessKey,
+		})
 
-	// verify delete api key for self (alt)
-	verifyDeleteAPIKey(t, false, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
-		UserSlug:  normalUser.Slug,
-		AccessKey: APIKeyRon2.AccessKey,
-	})
+		// verify delete api key for self (alt)
+		verifyDeleteAPIKey(t, false, ctx, db, normalUser.ID, services.DeleteAPIKeyInput{
+			UserSlug:  normalUser.Slug,
+			AccessKey: APIKeyRon2.AccessKey,
+		})
 
-	// verify delete api key for other (non-admin)
-	verifyDeleteAPIKey(t, true, ctx, db, targetUser.ID, services.DeleteAPIKeyInput{
-		UserSlug:  targetUser.Slug,
-		AccessKey: APIKeyHarry1.AccessKey,
-	})
+		// verify delete api key for other (non-admin)
+		verifyDeleteAPIKey(t, true, ctx, db, targetUser.ID, services.DeleteAPIKeyInput{
+			UserSlug:  targetUser.Slug,
+			AccessKey: APIKeyHarry1.AccessKey,
+		})
 
-	// verify delete api key for other (admin)
-	ctx = contextForUser(adminUser, db)
-	verifyDeleteAPIKey(t, false, ctx, db, targetUser.ID, services.DeleteAPIKeyInput{
-		UserSlug:  targetUser.Slug,
-		AccessKey: APIKeyHarry1.AccessKey,
+		// verify delete api key for other (admin)
+		ctx = contextForUser(adminUser, db)
+		verifyDeleteAPIKey(t, false, ctx, db, targetUser.ID, services.DeleteAPIKeyInput{
+			UserSlug:  targetUser.Slug,
+			AccessKey: APIKeyHarry1.AccessKey,
+		})
 	})
 }
 
@@ -121,24 +120,24 @@ func verifyDeleteAPIKey(t *testing.T, expectError bool, ctx context.Context, db 
 }
 
 func TestListAPIKeys(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	normalUser := UserRon
-	targetUser := UserHarry
-	adminUser := UserDumbledore
-	ctx := contextForUser(normalUser, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		targetUser := UserHarry
+		adminUser := UserDumbledore
+		ctx := contextForUser(normalUser, db)
 
-	// verify read-self
-	verifyListAPIKeys(t, false, ctx, db, "", APIKeyRon1, APIKeyRon2)
-	// verify read-self (alt)
-	verifyListAPIKeys(t, false, ctx, db, normalUser.Slug, APIKeyRon1, APIKeyRon2)
+		// verify read-self
+		verifyListAPIKeys(t, false, ctx, db, "", APIKeyRon1, APIKeyRon2)
+		// verify read-self (alt)
+		verifyListAPIKeys(t, false, ctx, db, normalUser.Slug, APIKeyRon1, APIKeyRon2)
 
-	// verify read-other (non-admin)
-	verifyListAPIKeys(t, true, ctx, db, targetUser.Slug)
+		// verify read-other (non-admin)
+		verifyListAPIKeys(t, true, ctx, db, targetUser.Slug)
 
-	// verify read-other (admin)
-	ctx = contextForUser(adminUser, db)
-	verifyListAPIKeys(t, false, ctx, db, targetUser.Slug, APIKeyHarry1, APIKeyHarry2)
+		// verify read-other (admin)
+		ctx = contextForUser(adminUser, db)
+		verifyListAPIKeys(t, false, ctx, db, targetUser.Slug, APIKeyHarry1, APIKeyHarry2)
+	})
 }
 
 func verifyListAPIKeys(t *testing.T, expectError bool, ctx context.Context, db *database.Connection, userSlug string, expectedAPIKeys ...models.APIKey) {

--- a/backend/services/auth_scheme_test.go
+++ b/backend/services/auth_scheme_test.go
@@ -17,70 +17,68 @@ import (
 )
 
 func TestDeleteAuthScheme(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		targetUser := UserHarry
+		ctx := contextForUser(normalUser, db)
+		schemeName := localConsts.Code
+		recoveryScheme := recoveryConsts.Code
 
-	normalUser := UserRon
-	targetUser := UserHarry
-	ctx := contextForUser(normalUser, db)
-	schemeName := localConsts.Code
-	recoveryScheme := recoveryConsts.Code
+		// seed recovery data
+		users := []models.User{normalUser, targetUser}
+		err := db.BatchInsert("auth_scheme_data", len(users), func(i int) map[string]interface{} {
+			return map[string]interface{}{
+				"auth_scheme": recoveryScheme,
+				"auth_type":   recoveryScheme,
+				"user_key":    users[i].FirstName,
+				"user_id":     users[i].ID,
+			}
+		})
+		require.NoError(t, err)
 
-	// seed recovery data
-	users := []models.User{normalUser, targetUser}
-	err := db.BatchInsert("auth_scheme_data", len(users), func(i int) map[string]interface{} {
-		return map[string]interface{}{
-			"auth_scheme": recoveryScheme,
-			"auth_type":   recoveryScheme,
-			"user_key":    users[i].FirstName,
-			"user_id":     users[i].ID,
-		}
-	})
-	require.NoError(t, err)
+		// verify cannot delete recovery
+		verifyDeletedScheme(t, true, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
+			SchemeName: recoveryConsts.Code,
+		})
 
-	// verify cannot delete recovery
-	verifyDeletedScheme(t, true, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
-		SchemeName: recoveryConsts.Code,
-	})
+		// verify delete auth for self
+		verifyDeletedScheme(t, false, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
+			SchemeName: schemeName,
+		})
 
-	// verify delete auth for self
-	verifyDeletedScheme(t, false, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
-		SchemeName: schemeName,
-	})
+		// add back in deleted auth
+		_, err = db.Insert("auth_scheme_data", map[string]interface{}{
+			"auth_scheme": schemeName,
+			"auth_type":   schemeName,
+			"user_key":    normalUser.FirstName,
+			"user_id":     normalUser.ID,
+		})
+		require.NoError(t, err)
 
-	// add back in deleted auth
-	_, err = db.Insert("auth_scheme_data", map[string]interface{}{
-		"auth_scheme": schemeName,
-		"auth_type":   schemeName,
-		"user_key":    normalUser.FirstName,
-		"user_id":     normalUser.ID,
-	})
-	require.NoError(t, err)
+		// verify delete auth for self (alt)
+		verifyDeletedScheme(t, false, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
+			UserSlug:   normalUser.Slug,
+			SchemeName: schemeName,
+		})
 
-	// verify delete auth for self (alt)
-	verifyDeletedScheme(t, false, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
-		UserSlug:   normalUser.Slug,
-		SchemeName: schemeName,
-	})
+		// verify delete auth for other (non-admin)
+		verifyDeletedScheme(t, true, ctx, db, targetUser.ID, services.DeleteAuthSchemeInput{
+			UserSlug:   targetUser.Slug,
+			SchemeName: schemeName,
+		})
 
-	// verify delete auth for other (non-admin)
-	verifyDeletedScheme(t, true, ctx, db, targetUser.ID, services.DeleteAuthSchemeInput{
-		UserSlug:   targetUser.Slug,
-		SchemeName: schemeName,
-	})
+		// verify delete auth for other (admin)
+		ctx = contextForUser(UserDumbledore, db)
+		verifyDeletedScheme(t, false, ctx, db, targetUser.ID, services.DeleteAuthSchemeInput{
+			UserSlug:   targetUser.Slug,
+			SchemeName: schemeName,
+		})
 
-	// verify delete auth for other (admin)
-	ctx = contextForUser(UserDumbledore, db)
-	verifyDeletedScheme(t, false, ctx, db, targetUser.ID, services.DeleteAuthSchemeInput{
-		UserSlug:   targetUser.Slug,
-		SchemeName: schemeName,
-	})
-
-	// verify cannot delete recovery (admin)
-	verifyDeletedScheme(t, true, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
-		UserSlug:   targetUser.Slug,
-		SchemeName: recoveryConsts.Code,
+		// verify cannot delete recovery (admin)
+		verifyDeletedScheme(t, true, ctx, db, normalUser.ID, services.DeleteAuthSchemeInput{
+			UserSlug:   targetUser.Slug,
+			SchemeName: recoveryConsts.Code,
+		})
 	})
 }
 
@@ -101,33 +99,31 @@ func verifyDeletedScheme(t *testing.T, expectError bool, ctx context.Context, db
 }
 
 func TestDeleteAuthSchemeUsers(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		adminUser := UserDumbledore
+		schemeName := localConsts.Code
 
-	normalUser := UserRon
-	adminUser := UserDumbledore
-	schemeName := localConsts.Code
+		baseUsers := getUsersForAuth(t, db, schemeName)
+		require.Greater(t, len(baseUsers), 0)
 
-	baseUsers := getUsersForAuth(t, db, schemeName)
-	require.Greater(t, len(baseUsers), 0)
+		// verify non-admins have no access
+		ctx := contextForUser(normalUser, db)
+		err := services.DeleteAuthSchemeUsers(ctx, db, schemeName)
+		require.Error(t, err)
 
-	// verify non-admins have no access
-	ctx := contextForUser(normalUser, db)
-	err := services.DeleteAuthSchemeUsers(ctx, db, schemeName)
-	require.Error(t, err)
+		// verify admins have access + effect works
+		ctx = contextForUser(adminUser, db)
+		err = services.DeleteAuthSchemeUsers(ctx, db, schemeName)
+		require.NoError(t, err)
 
-	// verify admins have access + effect works
-	ctx = contextForUser(adminUser, db)
-	err = services.DeleteAuthSchemeUsers(ctx, db, schemeName)
-	require.NoError(t, err)
+		updatedUsers := getUsersForAuth(t, db, schemeName)
+		require.Equal(t, 0, len(updatedUsers))
 
-	updatedUsers := getUsersForAuth(t, db, schemeName)
-	require.Equal(t, 0, len(updatedUsers))
-
-	// verify admins cannot delete recovery
-	err = services.DeleteAuthSchemeUsers(ctx, db, recoveryConsts.Code)
-	require.Error(t, err)
+		// verify admins cannot delete recovery
+		err = services.DeleteAuthSchemeUsers(ctx, db, recoveryConsts.Code)
+		require.Error(t, err)
+	})
 }
 
 var patronusAuthScheme = dtos.SupportedAuthScheme{SchemeName: "Patronus Charm", SchemeCode: "patronus", SchemeType: "magical"}
@@ -135,83 +131,81 @@ var localAuthScheme = dtos.SupportedAuthScheme{SchemeName: localConsts.FriendlyN
 var darkMarkScheme = dtos.SupportedAuthScheme{SchemeName: "Death Eaters", SchemeCode: "dark mark", SchemeType: "magical"}
 
 func TestListAuthDetailsKeys(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		adminUser := UserDumbledore
 
-	normalUser := UserRon
-	adminUser := UserDumbledore
-
-	supportedSchemes := []dtos.SupportedAuthScheme{
-		localAuthScheme,
-		patronusAuthScheme,
-	}
-
-	// verify non-admins cannot access this service
-	ctx := contextForUser(normalUser, db)
-	_, err := services.ListAuthDetails(ctx, db, &supportedSchemes)
-	require.Error(t, err)
-
-	// verify list for admins
-	ctx = contextForUser(adminUser, db)
-	results, err := services.ListAuthDetails(ctx, db, &supportedSchemes)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(results))
-
-	var schemePatronus *dtos.DetailedAuthenticationInfo
-	var schemeLocal *dtos.DetailedAuthenticationInfo
-	for _, scheme := range results {
-		if scheme.AuthSchemeCode == localAuthScheme.SchemeCode {
-			schemeLocal = scheme
+		supportedSchemes := []dtos.SupportedAuthScheme{
+			localAuthScheme,
+			patronusAuthScheme,
 		}
-		if scheme.AuthSchemeCode == patronusAuthScheme.SchemeCode {
-			schemePatronus = scheme
+
+		// verify non-admins cannot access this service
+		ctx := contextForUser(normalUser, db)
+		_, err := services.ListAuthDetails(ctx, db, &supportedSchemes)
+		require.Error(t, err)
+
+		// verify list for admins
+		ctx = contextForUser(adminUser, db)
+		results, err := services.ListAuthDetails(ctx, db, &supportedSchemes)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(results))
+
+		var schemePatronus *dtos.DetailedAuthenticationInfo
+		var schemeLocal *dtos.DetailedAuthenticationInfo
+		for _, scheme := range results {
+			if scheme.AuthSchemeCode == localAuthScheme.SchemeCode {
+				schemeLocal = scheme
+			}
+			if scheme.AuthSchemeCode == patronusAuthScheme.SchemeCode {
+				schemePatronus = scheme
+			}
 		}
-	}
-	// verify expected results
-	require.NotNil(t, schemePatronus)
-	require.NotNil(t, schemeLocal)
+		// verify expected results
+		require.NotNil(t, schemePatronus)
+		require.NotNil(t, schemeLocal)
 
-	require.Equal(t, int64(0), schemePatronus.UserCount)
-	require.Equal(t, int64(0), schemePatronus.UniqueUserCount)
-	require.Equal(t, 0, len(schemePatronus.Labels))
+		require.Equal(t, int64(0), schemePatronus.UserCount)
+		require.Equal(t, int64(0), schemePatronus.UniqueUserCount)
+		require.Equal(t, 0, len(schemePatronus.Labels))
 
-	realUserCount := int64(len(getRealUsers(t, db)))
-	require.Equal(t, realUserCount, schemeLocal.UserCount)
-	require.Equal(t, realUserCount, schemeLocal.UniqueUserCount)
-	require.Equal(t, 0, len(schemeLocal.Labels))
+		realUserCount := int64(len(getRealUsers(t, db)))
+		require.Equal(t, realUserCount, schemeLocal.UserCount)
+		require.Equal(t, realUserCount, schemeLocal.UniqueUserCount)
+		require.Equal(t, 0, len(schemeLocal.Labels))
 
-	// Add in an unsupported scheme
-	_, err = db.Insert("auth_scheme_data", map[string]interface{}{
-		"auth_scheme": darkMarkScheme.SchemeCode,
-		"user_key":    "Half-Blood Prince",
-		"user_id":     UserSnape.ID,
-		"auth_type":   darkMarkScheme.SchemeType,
+		// Add in an unsupported scheme
+		_, err = db.Insert("auth_scheme_data", map[string]interface{}{
+			"auth_scheme": darkMarkScheme.SchemeCode,
+			"user_key":    "Half-Blood Prince",
+			"user_id":     UserSnape.ID,
+			"auth_type":   darkMarkScheme.SchemeType,
+		})
+
+		require.NoError(t, err)
+		results, err = services.ListAuthDetails(ctx, db, &supportedSchemes)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(results))
+		var schemeDarkMark *dtos.DetailedAuthenticationInfo
+
+		for _, scheme := range results {
+			if scheme.AuthSchemeCode == darkMarkScheme.SchemeCode {
+				schemeDarkMark = scheme
+			}
+			if scheme.AuthSchemeCode == localAuthScheme.SchemeCode {
+				schemeLocal = scheme
+			}
+		}
+		require.NotNil(t, schemeDarkMark)
+
+		// verify count whent down for local
+		require.Equal(t, realUserCount, schemeLocal.UserCount)
+		require.Equal(t, realUserCount-1, schemeLocal.UniqueUserCount)
+		require.Equal(t, 0, len(schemeLocal.Labels))
+
+		require.Equal(t, int64(1), schemeDarkMark.UserCount)
+		require.Equal(t, int64(0), schemeDarkMark.UniqueUserCount)
+		require.Equal(t, 1, len(schemeDarkMark.Labels))
+		require.Equal(t, "Unsupported", schemeDarkMark.Labels[0])
 	})
-
-	require.NoError(t, err)
-	results, err = services.ListAuthDetails(ctx, db, &supportedSchemes)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(results))
-	var schemeDarkMark *dtos.DetailedAuthenticationInfo
-
-	for _, scheme := range results {
-		if scheme.AuthSchemeCode == darkMarkScheme.SchemeCode {
-			schemeDarkMark = scheme
-		}
-		if scheme.AuthSchemeCode == localAuthScheme.SchemeCode {
-			schemeLocal = scheme
-		}
-	}
-	require.NotNil(t, schemeDarkMark)
-
-	// verify count whent down for local
-	require.Equal(t, realUserCount, schemeLocal.UserCount)
-	require.Equal(t, realUserCount-1, schemeLocal.UniqueUserCount)
-	require.Equal(t, 0, len(schemeLocal.Labels))
-
-	require.Equal(t, int64(1), schemeDarkMark.UserCount)
-	require.Equal(t, int64(0), schemeDarkMark.UniqueUserCount)
-	require.Equal(t, 1, len(schemeDarkMark.Labels))
-	require.Equal(t, "Unsupported", schemeDarkMark.Labels[0])
 }

--- a/backend/services/evidence_metadata_test.go
+++ b/backend/services/evidence_metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/helpers"
 	"github.com/theparanoids/ashirt-server/backend/models"
@@ -14,183 +15,183 @@ import (
 )
 
 func TestCreateEvidenceMetadata(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	op := OpChamberOfSecrets
-	evi := EviDobby
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		op := OpChamberOfSecrets
+		evi := EviDobby
 
-	input := services.EditEvidenceMetadataInput{
-		OperationSlug: op.Slug,
-		EvidenceUUID:  evi.UUID,
-		Source:        "Insert Source",
-		Body:          "some-body",
-	}
-	tryInsert := func(u models.User, input services.EditEvidenceMetadataInput) error {
-		ctx := contextForUser(u, db)
-		return services.CreateEvidenceMetadata(ctx, db, input)
-	}
-
-	// verify permissions
-	require.Error(t, tryInsert(UserDraco, input))  // no operation access
-	require.Error(t, tryInsert(UserSeamus, input)) // read access
-
-	// verify insert
-	require.NoError(t, tryInsert(UserRon, input)) // normal access
-
-	metadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
-	require.NotEmpty(t, metadataList)
-	for _, v := range metadataList {
-		if v.Source == input.Source {
-			require.Equal(t, input.Body, v.Body)
-			break
+		input := services.EditEvidenceMetadataInput{
+			OperationSlug: op.Slug,
+			EvidenceUUID:  evi.UUID,
+			Source:        "Insert Source",
+			Body:          "some-body",
 		}
-	}
+		tryInsert := func(u models.User, input services.EditEvidenceMetadataInput) error {
+			ctx := contextForUser(u, db)
+			return services.CreateEvidenceMetadata(ctx, db, input)
+		}
+
+		// verify permissions
+		require.Error(t, tryInsert(UserDraco, input))  // no operation access
+		require.Error(t, tryInsert(UserSeamus, input)) // read access
+
+		// verify insert
+		require.NoError(t, tryInsert(UserRon, input)) // normal access
+
+		metadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
+		require.NotEmpty(t, metadataList)
+		for _, v := range metadataList {
+			if v.Source == input.Source {
+				require.Equal(t, input.Body, v.Body)
+				break
+			}
+		}
+	})
 }
 
 func TestUpdateEvidenceMetadata(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	op := OpChamberOfSecrets
-	evi := EviDobby
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		op := OpChamberOfSecrets
+		evi := EviDobby
 
-	input := services.EditEvidenceMetadataInput{
-		OperationSlug: op.Slug,
-		EvidenceUUID:  evi.UUID,
-		Source:        "Update Source",
-		Body:          "some-body",
-	}
-
-	author := UserRon
-	// update evidence metadata
-	ctx := contextForUser(author, db)
-	err := services.CreateEvidenceMetadata(ctx, db, input)
-	require.NoError(t, err)
-
-	tryUpdate := func(u models.User, input services.EditEvidenceMetadataInput) error {
-		ctx := contextForUser(u, db)
-		return services.UpdateEvidenceMetadata(ctx, db, input)
-	}
-	input.Body = "new-body"
-
-	// verify permissions
-	require.Error(t, tryUpdate(UserDraco, input))  // no operation access
-	require.Error(t, tryUpdate(UserSeamus, input)) // read access
-
-	// verify Update
-	require.NoError(t, tryUpdate(author, input))
-
-	metadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
-	require.NotEmpty(t, metadataList)
-	for _, v := range metadataList {
-		if v.Source == input.Source {
-			require.Equal(t, input.Body, v.Body)
-			break
+		input := services.EditEvidenceMetadataInput{
+			OperationSlug: op.Slug,
+			EvidenceUUID:  evi.UUID,
+			Source:        "Update Source",
+			Body:          "some-body",
 		}
-	}
+
+		author := UserRon
+		// update evidence metadata
+		ctx := contextForUser(author, db)
+		err := services.CreateEvidenceMetadata(ctx, db, input)
+		require.NoError(t, err)
+
+		tryUpdate := func(u models.User, input services.EditEvidenceMetadataInput) error {
+			ctx := contextForUser(u, db)
+			return services.UpdateEvidenceMetadata(ctx, db, input)
+		}
+		input.Body = "new-body"
+
+		// verify permissions
+		require.Error(t, tryUpdate(UserDraco, input))  // no operation access
+		require.Error(t, tryUpdate(UserSeamus, input)) // read access
+
+		// verify Update
+		require.NoError(t, tryUpdate(author, input))
+
+		metadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
+		require.NotEmpty(t, metadataList)
+		for _, v := range metadataList {
+			if v.Source == input.Source {
+				require.Equal(t, input.Body, v.Body)
+				break
+			}
+		}
+	})
 }
 
 func TestUpsertEvidenceMetadata(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	op := OpChamberOfSecrets
-	evi := EviDobby
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		op := OpChamberOfSecrets
+		evi := EviDobby
 
-	input := services.UpsertEvidenceMetadataInput{
-		EditEvidenceMetadataInput: services.EditEvidenceMetadataInput{
-			OperationSlug: op.Slug,
-			EvidenceUUID:  evi.UUID,
-			Source:        "Upsert Source",
-			Body:          "",
-		},
-		Status:     "failed",
-		Message:    helpers.Ptr("that didn't work"),
-		CanProcess: helpers.Ptr(true),
-	}
+		input := services.UpsertEvidenceMetadataInput{
+			EditEvidenceMetadataInput: services.EditEvidenceMetadataInput{
+				OperationSlug: op.Slug,
+				EvidenceUUID:  evi.UUID,
+				Source:        "Upsert Source",
+				Body:          "",
+			},
+			Status:     "failed",
+			Message:    helpers.Ptr("that didn't work"),
+			CanProcess: helpers.Ptr(true),
+		}
 
-	tryUpsert := func(u models.User, input services.UpsertEvidenceMetadataInput) error {
-		ctx := contextForUser(u, db)
-		return services.UpsertEvidenceMetadata(ctx, db, input)
-	}
+		tryUpsert := func(u models.User, input services.UpsertEvidenceMetadataInput) error {
+			ctx := contextForUser(u, db)
+			return services.UpsertEvidenceMetadata(ctx, db, input)
+		}
 
-	// verify permissions
-	require.Error(t, tryUpsert(UserDraco, input))  // no operation access
-	require.Error(t, tryUpsert(UserSeamus, input)) // read access
+		// verify permissions
+		require.Error(t, tryUpsert(UserDraco, input))  // no operation access
+		require.Error(t, tryUpsert(UserSeamus, input)) // read access
 
-	author := UserRon
-	// add evidence metadata
-	require.NoError(t, tryUpsert(author, input))
+		author := UserRon
+		// add evidence metadata
+		require.NoError(t, tryUpsert(author, input))
 
-	metadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
-	require.NotEmpty(t, metadataList)
-	_, metadataEntry := helpers.Find(metadataList, func(t models.EvidenceMetadata) bool {
-		return t.Source == input.Source
+		metadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
+		require.NotEmpty(t, metadataList)
+		_, metadataEntry := helpers.Find(metadataList, func(t models.EvidenceMetadata) bool {
+			return t.Source == input.Source
+		})
+		require.NotNil(t, metadataEntry)
+		require.Equal(t, input.Body, metadataEntry.Body)
+		require.Equal(t, input.CanProcess, metadataEntry.CanProcess)
+		require.Equal(t, input.Message, input.Message)
+		require.Equal(t, input.Status, input.Status)
+
+		input.Body = "new-body"
+		input.Status = "sucess"
+		input.Message = nil
+		input.CanProcess = nil
+
+		// verify Update
+		require.NoError(t, tryUpsert(author, input))
+
+		metadataList = getEvidenceMetadataByEvidenceID(t, db, evi.ID)
+		require.NotEmpty(t, metadataList)
+		_, metadataEntry = helpers.Find(metadataList, func(t models.EvidenceMetadata) bool {
+			return t.Source == input.Source
+		})
+		require.NotNil(t, metadataEntry)
+		require.Equal(t, input.Body, metadataEntry.Body)
+		require.Equal(t, input.CanProcess, metadataEntry.CanProcess)
+		require.Equal(t, input.Message, input.Message)
+		require.Equal(t, input.Status, input.Status)
 	})
-	require.NotNil(t, metadataEntry)
-	require.Equal(t, input.Body, metadataEntry.Body)
-	require.Equal(t, input.CanProcess, metadataEntry.CanProcess)
-	require.Equal(t, input.Message, input.Message)
-	require.Equal(t, input.Status, input.Status)
-
-	input.Body = "new-body"
-	input.Status = "sucess"
-	input.Message = nil
-	input.CanProcess = nil
-
-	// verify Update
-	require.NoError(t, tryUpsert(author, input))
-
-	metadataList = getEvidenceMetadataByEvidenceID(t, db, evi.ID)
-	require.NotEmpty(t, metadataList)
-	_, metadataEntry = helpers.Find(metadataList, func(t models.EvidenceMetadata) bool {
-		return t.Source == input.Source
-	})
-	require.NotNil(t, metadataEntry)
-	require.Equal(t, input.Body, metadataEntry.Body)
-	require.Equal(t, input.CanProcess, metadataEntry.CanProcess)
-	require.Equal(t, input.Message, input.Message)
-	require.Equal(t, input.Status, input.Status)
 }
 
 func TestReadEvidenceMetadata(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	op := OpChamberOfSecrets
-	evi := EviDobby
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		op := OpChamberOfSecrets
+		evi := EviDobby
 
-	originalMetadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
-	require.NotEmpty(t, originalMetadataList, "Metadata should be present here.")
+		originalMetadataList := getEvidenceMetadataByEvidenceID(t, db, evi.ID)
+		require.NotEmpty(t, originalMetadataList, "Metadata should be present here.")
 
-	tryRead := func(u models.User, input services.ReadEvidenceMetadataInput, metadata *[]*dtos.EvidenceMetadata) error {
-		ctx := contextForUser(u, db)
-		data, err := services.ReadEvidenceMetadata(ctx, db, input)
-		// metadata = &data
-		*metadata = data
-		return err
-	}
-
-	input := services.ReadEvidenceMetadataInput{
-		OperationSlug: op.Slug,
-		EvidenceUUID:  evi.UUID,
-	}
-
-	var meta []*dtos.EvidenceMetadata
-	// verify permissions
-	require.Error(t, tryRead(UserDraco, input, &meta))    // no operation access
-	require.NoError(t, tryRead(UserSeamus, input, &meta)) // read access
-
-	// verify read
-	require.NoError(t, tryRead(UserRon, input, &meta)) // normal access
-
-	// verify items in result set
-	require.Equal(t, len(originalMetadataList), len(meta))
-	for _, v := range originalMetadataList {
-		found := false
-		for _, w := range meta {
-			if w.Source == v.Source {
-				require.Equal(t, v.Body, w.Body)
-				found = true
-			}
+		tryRead := func(u models.User, input services.ReadEvidenceMetadataInput, metadata *[]*dtos.EvidenceMetadata) error {
+			ctx := contextForUser(u, db)
+			data, err := services.ReadEvidenceMetadata(ctx, db, input)
+			// metadata = &data
+			*metadata = data
+			return err
 		}
-		require.True(t, found, "Couldn't find metadata for source")
-	}
+
+		input := services.ReadEvidenceMetadataInput{
+			OperationSlug: op.Slug,
+			EvidenceUUID:  evi.UUID,
+		}
+
+		var meta []*dtos.EvidenceMetadata
+		// verify permissions
+		require.Error(t, tryRead(UserDraco, input, &meta))    // no operation access
+		require.NoError(t, tryRead(UserSeamus, input, &meta)) // read access
+
+		// verify read
+		require.NoError(t, tryRead(UserRon, input, &meta)) // normal access
+
+		// verify items in result set
+		require.Equal(t, len(originalMetadataList), len(meta))
+		for _, v := range originalMetadataList {
+			found := false
+			for _, w := range meta {
+				if w.Source == v.Source {
+					require.Equal(t, v.Body, w.Body)
+					found = true
+				}
+			}
+			require.True(t, found, "Couldn't find metadata for source")
+		}
+	})
 }

--- a/backend/services/evidence_test.go
+++ b/backend/services/evidence_test.go
@@ -22,145 +22,140 @@ import (
 type evidenceValidator func(*testing.T, FullEvidence, dtos.Evidence)
 
 func TestCreateEvidence(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		memStore, _ := contentstore.NewMemStore()
+		normalUser := UserRon
+		ctx := contextForUser(normalUser, db)
 
-	memStore, _ := contentstore.NewMemStore()
-	normalUser := UserRon
-	ctx := contextForUser(normalUser, db)
+		op := OpChamberOfSecrets
+		imgContent := TinyImg
+		imgInput := services.CreateEvidenceInput{
+			OperationSlug: op.Slug,
+			Description:   "some image",
+			ContentType:   "image",
+			TagIDs:        TagIDsFromTags(TagSaturn, TagJupiter),
+			Content:       bytes.NewReader(imgContent),
+		}
+		imgEvi, err := services.CreateEvidence(ctx, db, memStore, imgInput)
+		require.NoError(t, err)
+		validateInsertedEvidence(t, imgEvi, imgInput, normalUser, op, memStore, db, imgContent)
 
-	op := OpChamberOfSecrets
-	imgContent := TinyImg
-	imgInput := services.CreateEvidenceInput{
-		OperationSlug: op.Slug,
-		Description:   "some image",
-		ContentType:   "image",
-		TagIDs:        TagIDsFromTags(TagSaturn, TagJupiter),
-		Content:       bytes.NewReader(imgContent),
-	}
-	imgEvi, err := services.CreateEvidence(ctx, db, memStore, imgInput)
-	require.NoError(t, err)
-	validateInsertedEvidence(t, imgEvi, imgInput, normalUser, op, memStore, db, imgContent)
+		cbContent := []byte("I'm a codeblock!")
+		cbInput := services.CreateEvidenceInput{
+			OperationSlug: op.Slug,
+			Description:   "some codeblock",
+			ContentType:   "codeblock",
+			TagIDs:        TagIDsFromTags(TagVenus, TagMars),
+			Content:       bytes.NewReader(cbContent),
+		}
+		cbEvi, err := services.CreateEvidence(ctx, db, memStore, cbInput)
+		require.NoError(t, err)
+		validateInsertedEvidence(t, cbEvi, cbInput, normalUser, op, memStore, db, cbContent)
 
-	cbContent := []byte("I'm a codeblock!")
-	cbInput := services.CreateEvidenceInput{
-		OperationSlug: op.Slug,
-		Description:   "some codeblock",
-		ContentType:   "codeblock",
-		TagIDs:        TagIDsFromTags(TagVenus, TagMars),
-		Content:       bytes.NewReader(cbContent),
-	}
-	cbEvi, err := services.CreateEvidence(ctx, db, memStore, cbInput)
-	require.NoError(t, err)
-	validateInsertedEvidence(t, cbEvi, cbInput, normalUser, op, memStore, db, cbContent)
-
-	bareInput := services.CreateEvidenceInput{
-		OperationSlug: op.Slug,
-		Description:   "Just a note here",
-		ContentType:   "Plain Text",
-		TagIDs:        TagIDsFromTags(TagVenus, TagMars),
-	}
-	bareEvi, err := services.CreateEvidence(ctx, db, memStore, bareInput)
-	require.NoError(t, err)
-	validateInsertedEvidence(t, bareEvi, bareInput, normalUser, op, memStore, db, nil)
+		bareInput := services.CreateEvidenceInput{
+			OperationSlug: op.Slug,
+			Description:   "Just a note here",
+			ContentType:   "Plain Text",
+			TagIDs:        TagIDsFromTags(TagVenus, TagMars),
+		}
+		bareEvi, err := services.CreateEvidence(ctx, db, memStore, bareInput)
+		require.NoError(t, err)
+		validateInsertedEvidence(t, bareEvi, bareInput, normalUser, op, memStore, db, nil)
+	})
 }
 
 func TestHeadlessUserAccess(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	memStore, _ := contentstore.NewMemStore()
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		memStore, _ := contentstore.NewMemStore()
 
-	headlessUser := UserHeadlessNick
-	op := OpChamberOfSecrets
+		headlessUser := UserHeadlessNick
+		op := OpChamberOfSecrets
 
-	// Pre-test: verify that the user is not a normal member of the operation
-	opRoles := getUserRolesForOperationByOperationID(t, db, op.ID)
-	for _, v := range opRoles {
-		require.NotEqual(t, v.UserID, headlessUser.ID, "Pretest error: User should not have normal access to this operation")
-	}
+		// Pre-test: verify that the user is not a normal member of the operation
+		opRoles := getUserRolesForOperationByOperationID(t, db, op.ID)
+		for _, v := range opRoles {
+			require.NotEqual(t, v.UserID, headlessUser.ID, "Pretest error: User should not have normal access to this operation")
+		}
 
-	ctx := contextForUser(headlessUser, db)
+		ctx := contextForUser(headlessUser, db)
 
-	imgContent := TinyImg
-	imgInput := services.CreateEvidenceInput{
-		OperationSlug: op.Slug,
-		Description:   "headless image",
-		ContentType:   "image",
-		TagIDs:        TagIDsFromTags(TagSaturn, TagJupiter),
-		Content:       bytes.NewReader(imgContent),
-	}
-	imgEvi, err := services.CreateEvidence(ctx, db, memStore, imgInput)
-	require.NoError(t, err)
-	fullEvidence := getEvidenceByUUID(t, db, imgEvi.UUID)
-	require.Equal(t, imgInput.Description, fullEvidence.Description)
+		imgContent := TinyImg
+		imgInput := services.CreateEvidenceInput{
+			OperationSlug: op.Slug,
+			Description:   "headless image",
+			ContentType:   "image",
+			TagIDs:        TagIDsFromTags(TagSaturn, TagJupiter),
+			Content:       bytes.NewReader(imgContent),
+		}
+		imgEvi, err := services.CreateEvidence(ctx, db, memStore, imgInput)
+		require.NoError(t, err)
+		fullEvidence := getEvidenceByUUID(t, db, imgEvi.UUID)
+		require.Equal(t, imgInput.Description, fullEvidence.Description)
+	})
 }
 
 func TestDeleteEvidenceNoPropogate(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	op := OpChamberOfSecrets
-	memStore := createPopulatedMemStore(HarryPotterSeedData)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		op := OpChamberOfSecrets
+		memStore := createPopulatedMemStore(seed)
 
-	masterEvidence := EviFlyingCar
-	i := services.DeleteEvidenceInput{
-		OperationSlug:            op.Slug,
-		EvidenceUUID:             masterEvidence.UUID,
-		DeleteAssociatedFindings: false,
-	}
-	// populate content store
-	contentStoreKey := masterEvidence.UUID // seed data shares full and thumb key ids
+		masterEvidence := EviFlyingCar
+		i := services.DeleteEvidenceInput{
+			OperationSlug:            op.Slug,
+			EvidenceUUID:             masterEvidence.UUID,
+			DeleteAssociatedFindings: false,
+		}
+		// populate content store
+		contentStoreKey := masterEvidence.UUID // seed data shares full and thumb key ids
 
-	getAssociatedTagCount := makeDBRowCounter(t, db, "tag_evidence_map", "evidence_id=?", masterEvidence.ID)
-	require.True(t, getAssociatedTagCount() > 0, "Database should have associated tags to delete")
+		getAssociatedTagCount := makeDBRowCounter(t, db, "tag_evidence_map", "evidence_id=?", masterEvidence.ID)
+		require.True(t, getAssociatedTagCount() > 0, "Database should have associated tags to delete")
 
-	getEvidenceCount := makeDBRowCounter(t, db, "evidence", "uuid=?", i.EvidenceUUID)
-	require.Equal(t, int64(1), getEvidenceCount(), "Database should have evidence to delete")
+		getEvidenceCount := makeDBRowCounter(t, db, "evidence", "uuid=?", i.EvidenceUUID)
+		require.Equal(t, int64(1), getEvidenceCount(), "Database should have evidence to delete")
 
-	ctx := contextForUser(UserRon, db)
-	err := services.DeleteEvidence(ctx, db, memStore, i)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), getEvidenceCount(), "Database should have deleted the evidence")
-	require.Equal(t, int64(0), getAssociatedTagCount(), "Database should have deleted associated tags")
-	_, err = memStore.Read(contentStoreKey)
-	require.Error(t, err)
+		ctx := contextForUser(UserRon, db)
+		err := services.DeleteEvidence(ctx, db, memStore, i)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), getEvidenceCount(), "Database should have deleted the evidence")
+		require.Equal(t, int64(0), getAssociatedTagCount(), "Database should have deleted associated tags")
+		_, err = memStore.Read(contentStoreKey)
+		require.Error(t, err)
+	})
 }
 
 func TestDeleteEvidenceWithPropogation(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
-	memStore := createPopulatedMemStore(HarryPotterSeedData)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserRon, db)
+		memStore := createPopulatedMemStore(seed)
 
-	masterEvidence := EviDobby
-	i := services.DeleteEvidenceInput{
-		OperationSlug:            OpChamberOfSecrets.Slug,
-		EvidenceUUID:             masterEvidence.UUID,
-		DeleteAssociatedFindings: true,
-	}
-	getAssociatedTagCount := makeDBRowCounter(t, db, "tag_evidence_map", "evidence_id=?", masterEvidence.ID)
-	require.True(t, getAssociatedTagCount() > 0, "Database should have associated tags to delete")
+		masterEvidence := EviDobby
+		i := services.DeleteEvidenceInput{
+			OperationSlug:            OpChamberOfSecrets.Slug,
+			EvidenceUUID:             masterEvidence.UUID,
+			DeleteAssociatedFindings: true,
+		}
+		getAssociatedTagCount := makeDBRowCounter(t, db, "tag_evidence_map", "evidence_id=?", masterEvidence.ID)
+		require.True(t, getAssociatedTagCount() > 0, "Database should have associated tags to delete")
 
-	getEvidenceCount := makeDBRowCounter(t, db, "evidence", "uuid=?", masterEvidence.UUID)
-	require.Equal(t, int64(1), getEvidenceCount(), "Database should have evidence to delete")
+		getEvidenceCount := makeDBRowCounter(t, db, "evidence", "uuid=?", masterEvidence.UUID)
+		require.Equal(t, int64(1), getEvidenceCount(), "Database should have evidence to delete")
 
-	getMappedFindingCount := makeDBRowCounter(t, db, "evidence_finding_map", "evidence_id=?", masterEvidence.ID)
-	require.True(t, getMappedFindingCount() > 0, "Database should have some mapped finding to delete")
+		getMappedFindingCount := makeDBRowCounter(t, db, "evidence_finding_map", "evidence_id=?", masterEvidence.ID)
+		require.True(t, getMappedFindingCount() > 0, "Database should have some mapped finding to delete")
 
-	associatedFindingIDs := getAssociatedFindings(t, db, masterEvidence.ID)
-	require.True(t, len(associatedFindingIDs) > 0, "Database should have some associated finding to delete")
+		associatedFindingIDs := getAssociatedFindings(t, db, masterEvidence.ID)
+		require.True(t, len(associatedFindingIDs) > 0, "Database should have some associated finding to delete")
 
-	err := services.DeleteEvidence(ctx, db, memStore, i)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), getEvidenceCount(), "Database should have deleted the evidence")
-	require.Equal(t, int64(0), getAssociatedTagCount(), "Database should have deleted evidence-to-tags mappings")
-	require.Equal(t, int64(0), getMappedFindingCount(), "Database should have deleted evidence-to-findings mappings")
-	postDeleteFindingIDs := []int64{}
-	db.Select(&postDeleteFindingIDs, sq.Select("id").From("findings").Where(sq.Eq{"id": associatedFindingIDs}))
-	require.Equal(t, []int64{}, postDeleteFindingIDs, "Associated findings should be removed")
+		err := services.DeleteEvidence(ctx, db, memStore, i)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), getEvidenceCount(), "Database should have deleted the evidence")
+		require.Equal(t, int64(0), getAssociatedTagCount(), "Database should have deleted evidence-to-tags mappings")
+		require.Equal(t, int64(0), getMappedFindingCount(), "Database should have deleted evidence-to-findings mappings")
+		postDeleteFindingIDs := []int64{}
+		db.Select(&postDeleteFindingIDs, sq.Select("id").From("findings").Where(sq.Eq{"id": associatedFindingIDs}))
+		require.Equal(t, []int64{}, postDeleteFindingIDs, "Associated findings should be removed")
+	})
 }
 
 func getAssociatedFindings(t *testing.T, db *database.Connection, evidenceID int64) []int64 {
@@ -175,173 +170,173 @@ func getAssociatedFindings(t *testing.T, db *database.Connection, evidenceID int
 }
 
 func TestListEvidenceForFinding(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
-	masterFinding := FindingBook2Magic
-	allEvidence := getFullEvidenceByFindingID(t, db, masterFinding.ID)
+		masterOp := OpChamberOfSecrets
+		masterFinding := FindingBook2Magic
+		allEvidence := getFullEvidenceByFindingID(t, db, masterFinding.ID)
 
-	require.NotEqual(t, 0, len(allEvidence), "Some evidence should be present for this finding")
+		require.NotEqual(t, 0, len(allEvidence), "Some evidence should be present for this finding")
 
-	input := services.ListEvidenceForFindingInput{
-		OperationSlug: masterOp.Slug,
-		FindingUUID:   FindingBook2Magic.UUID,
-	}
+		input := services.ListEvidenceForFindingInput{
+			OperationSlug: masterOp.Slug,
+			FindingUUID:   FindingBook2Magic.UUID,
+		}
 
-	foundEvidence, err := services.ListEvidenceForFinding(ctx, db, input)
-	require.NoError(t, err)
-	require.Equal(t, len(foundEvidence), len(allEvidence))
-	validateEvidenceSets(t, foundEvidence, allEvidence, validateEvidence)
+		foundEvidence, err := services.ListEvidenceForFinding(ctx, db, input)
+		require.NoError(t, err)
+		require.Equal(t, len(foundEvidence), len(allEvidence))
+		validateEvidenceSets(t, foundEvidence, allEvidence, validateEvidence)
+	})
 }
 
 func TestListEvidenceForOperation(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
-	allEvidence := getFullEvidenceByOperationID(t, db, masterOp.ID)
+		masterOp := OpChamberOfSecrets
+		allEvidence := getFullEvidenceByOperationID(t, db, masterOp.ID)
 
-	require.NotEqual(t, len(allEvidence), 0, "Some evidence should be present")
+		require.NotEqual(t, len(allEvidence), 0, "Some evidence should be present")
 
-	input := services.ListEvidenceForOperationInput{
-		OperationSlug: masterOp.Slug,
-		Filters:       helpers.TimelineFilters{},
-	}
+		input := services.ListEvidenceForOperationInput{
+			OperationSlug: masterOp.Slug,
+			Filters:       helpers.TimelineFilters{},
+		}
 
-	foundEvidence, err := services.ListEvidenceForOperation(ctx, db, input)
-	require.NoError(t, err)
-	require.Equal(t, len(foundEvidence), len(allEvidence))
-	validateEvidenceSets(t, toRealEvidenceList(foundEvidence), allEvidence, validateEvidence)
+		foundEvidence, err := services.ListEvidenceForOperation(ctx, db, input)
+		require.NoError(t, err)
+		require.Equal(t, len(foundEvidence), len(allEvidence))
+		validateEvidenceSets(t, toRealEvidenceList(foundEvidence), allEvidence, validateEvidence)
+	})
 }
 
 func TestReadEvidence(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
-	cs, _ := contentstore.NewMemStore()
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
+		cs, _ := contentstore.NewMemStore()
 
-	masterOp := OpChamberOfSecrets
-	masterEvidence := cloneEvidence(EviFlyingCar) // cloning so we don't alter the underlying evidence for other tests
+		masterOp := OpChamberOfSecrets
+		masterEvidence := EviFlyingCar
 
-	neitherInput := services.ReadEvidenceInput{
-		OperationSlug: masterOp.Slug,
-		EvidenceUUID:  masterEvidence.UUID,
-	}
+		neitherInput := services.ReadEvidenceInput{
+			OperationSlug: masterOp.Slug,
+			EvidenceUUID:  masterEvidence.UUID,
+		}
 
-	retrievedEvidence, err := services.ReadEvidence(ctx, db, cs, neitherInput)
-	require.NoError(t, err)
-	validateReadEvidenceOutput(t, masterEvidence, retrievedEvidence)
+		retrievedEvidence, err := services.ReadEvidence(ctx, db, cs, neitherInput)
+		require.NoError(t, err)
+		validateReadEvidenceOutput(t, masterEvidence, retrievedEvidence)
 
-	fullImg := []byte("full_image")
-	thumbImg := []byte("thumb_image")
-	thumbKey, err := cs.Upload(bytes.NewReader(thumbImg))
-	require.NoError(t, err)
-	fullKey, err := cs.Upload(bytes.NewReader(fullImg))
-	require.NoError(t, err)
+		fullImg := []byte("full_image")
+		thumbImg := []byte("thumb_image")
+		thumbKey, err := cs.Upload(bytes.NewReader(thumbImg))
+		require.NoError(t, err)
+		fullKey, err := cs.Upload(bytes.NewReader(fullImg))
+		require.NoError(t, err)
 
-	err = db.Update(sq.Update("evidence").
-		SetMap(map[string]interface{}{
-			"full_image_key":  fullKey,
-			"thumb_image_key": thumbKey,
-		}).
-		Where(sq.Eq{"id": masterEvidence.ID}))
-	require.NoError(t, err)
-	masterEvidence.FullImageKey = fullKey
-	masterEvidence.ThumbImageKey = thumbKey
+		err = db.Update(sq.Update("evidence").
+			SetMap(map[string]interface{}{
+				"full_image_key":  fullKey,
+				"thumb_image_key": thumbKey,
+			}).
+			Where(sq.Eq{"id": masterEvidence.ID}))
+		require.NoError(t, err)
+		masterEvidence.FullImageKey = fullKey
+		masterEvidence.ThumbImageKey = thumbKey
 
-	retrievedEvidence, err = services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{
-		OperationSlug: masterOp.Slug,
-		EvidenceUUID:  masterEvidence.UUID,
-		LoadPreview:   true,
+		retrievedEvidence, err = services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{
+			OperationSlug: masterOp.Slug,
+			EvidenceUUID:  masterEvidence.UUID,
+			LoadPreview:   true,
+		})
+		require.NoError(t, err)
+		validateReadEvidenceOutput(t, masterEvidence, retrievedEvidence)
+		previewBytes, err := io.ReadAll(retrievedEvidence.Preview)
+		require.NoError(t, err)
+		require.Equal(t, thumbImg, previewBytes)
+
+		retrievedEvidence, err = services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{
+			OperationSlug: masterOp.Slug,
+			EvidenceUUID:  masterEvidence.UUID,
+			LoadMedia:     true,
+		})
+		require.NoError(t, err)
+		validateReadEvidenceOutput(t, masterEvidence, retrievedEvidence)
+		mediaBytes, err := io.ReadAll(retrievedEvidence.Media)
+		require.NoError(t, err)
+		require.Equal(t, fullImg, mediaBytes)
 	})
-	require.NoError(t, err)
-	validateReadEvidenceOutput(t, masterEvidence, retrievedEvidence)
-	previewBytes, err := io.ReadAll(retrievedEvidence.Preview)
-	require.NoError(t, err)
-	require.Equal(t, thumbImg, previewBytes)
-
-	retrievedEvidence, err = services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{
-		OperationSlug: masterOp.Slug,
-		EvidenceUUID:  masterEvidence.UUID,
-		LoadMedia:     true,
-	})
-	require.NoError(t, err)
-	validateReadEvidenceOutput(t, masterEvidence, retrievedEvidence)
-	mediaBytes, err := io.ReadAll(retrievedEvidence.Media)
-	require.NoError(t, err)
-	require.Equal(t, fullImg, mediaBytes)
 }
 
 func TestUpdateEvidence(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
-	cs, _ := contentstore.NewMemStore()
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserRon, db)
+		cs, _ := contentstore.NewMemStore()
 
-	// tests for common fields
-	masterOp := OpChamberOfSecrets
-	masterEvidence := EviFlyingCar
-	initialTags := HarryPotterSeedData.TagsForEvidence(masterEvidence)
-	tagToAdd := TagMercury
-	tagToRemove := TagSaturn
-	description := "New Description"
-	input := services.UpdateEvidenceInput{
-		OperationSlug: masterOp.Slug,
-		EvidenceUUID:  masterEvidence.UUID,
-		Description:   &description,
-		TagsToRemove:  []int64{tagToRemove.ID},
-		TagsToAdd:     []int64{tagToAdd.ID},
-	}
-	require.Contains(t, initialTags, tagToRemove)
-	require.NotContains(t, initialTags, tagToAdd)
-
-	err := services.UpdateEvidence(ctx, db, cs, input)
-	require.NoError(t, err)
-	evi, err := services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{OperationSlug: masterOp.Slug, EvidenceUUID: masterEvidence.UUID})
-	require.NoError(t, err)
-	require.Equal(t, *input.Description, evi.Description)
-	expectedTagIDs := make([]int64, 0, len(initialTags))
-	for _, t := range initialTags {
-		if t != tagToRemove {
-			expectedTagIDs = append(expectedTagIDs, t.ID)
+		// tests for common fields
+		masterOp := OpChamberOfSecrets
+		masterEvidence := EviFlyingCar
+		initialTags := seed.TagsForEvidence(masterEvidence)
+		tagToAdd := TagMercury
+		tagToRemove := TagSaturn
+		description := "New Description"
+		input := services.UpdateEvidenceInput{
+			OperationSlug: masterOp.Slug,
+			EvidenceUUID:  masterEvidence.UUID,
+			Description:   &description,
+			TagsToRemove:  []int64{tagToRemove.ID},
+			TagsToAdd:     []int64{tagToAdd.ID},
 		}
-	}
-	expectedTagIDs = append(expectedTagIDs, tagToAdd.ID)
-	require.Equal(t, sorted(expectedTagIDs), sorted(getTagIDsFromEvidenceID(t, db, masterEvidence.ID)))
+		require.Contains(t, initialTags, tagToRemove)
+		require.NotContains(t, initialTags, tagToAdd)
 
-	// test for content
+		err := services.UpdateEvidence(ctx, db, cs, input)
+		require.NoError(t, err)
+		evi, err := services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{OperationSlug: masterOp.Slug, EvidenceUUID: masterEvidence.UUID})
+		require.NoError(t, err)
+		require.Equal(t, *input.Description, evi.Description)
+		expectedTagIDs := make([]int64, 0, len(initialTags))
+		for _, t := range initialTags {
+			if t != tagToRemove {
+				expectedTagIDs = append(expectedTagIDs, t.ID)
+			}
+		}
+		expectedTagIDs = append(expectedTagIDs, tagToAdd.ID)
+		require.Equal(t, sorted(expectedTagIDs), sorted(getTagIDsFromEvidenceID(t, db, masterEvidence.ID)))
 
-	codeblockEvidence := EviTomRiddlesDiary
-	newContent := "stabbed_with_basilisk_fang = False\n\ndef is_alive():\n  return not stabbed_with_basilisk_fang\n"
-	input = services.UpdateEvidenceInput{
-		OperationSlug: masterOp.Slug,
-		EvidenceUUID:  codeblockEvidence.UUID,
-		Description:   &codeblockEvidence.Description, // Note: A quirk with UpdateEvidence is that it will always update the description, even if it is empty.
-		Content:       bytes.NewReader([]byte(newContent)),
-	}
+		// test for content
 
-	err = services.UpdateEvidence(ctx, db, cs, input)
-	require.NoError(t, err)
-	evi, err = services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{
-		OperationSlug: masterOp.Slug,
-		EvidenceUUID:  codeblockEvidence.UUID,
-		LoadMedia:     true,
-		LoadPreview:   true,
+		codeblockEvidence := EviTomRiddlesDiary
+		newContent := "stabbed_with_basilisk_fang = False\n\ndef is_alive():\n  return not stabbed_with_basilisk_fang\n"
+		input = services.UpdateEvidenceInput{
+			OperationSlug: masterOp.Slug,
+			EvidenceUUID:  codeblockEvidence.UUID,
+			Description:   &codeblockEvidence.Description, // Note: A quirk with UpdateEvidence is that it will always update the description, even if it is empty.
+			Content:       bytes.NewReader([]byte(newContent)),
+		}
+
+		err = services.UpdateEvidence(ctx, db, cs, input)
+		require.NoError(t, err)
+		evi, err = services.ReadEvidence(ctx, db, cs, services.ReadEvidenceInput{
+			OperationSlug: masterOp.Slug,
+			EvidenceUUID:  codeblockEvidence.UUID,
+			LoadMedia:     true,
+			LoadPreview:   true,
+		})
+		require.NoError(t, err)
+		mediaBytes, err := io.ReadAll(evi.Media)
+		require.NoError(t, err)
+		previewBytes, err := io.ReadAll(evi.Preview)
+		require.NoError(t, err)
+		require.Equal(t, mediaBytes, previewBytes, "Preview and Media content should be identical for codeblocks")
+		require.Equal(t, []byte(newContent), previewBytes)
+
+		updatedEvidence := getEvidenceByID(t, db, codeblockEvidence.ID)
+		require.Equal(t, updatedEvidence.ThumbImageKey, updatedEvidence.FullImageKey)
+		require.NotEqual(t, "", updatedEvidence.FullImageKey)
 	})
-	require.NoError(t, err)
-	mediaBytes, err := io.ReadAll(evi.Media)
-	require.NoError(t, err)
-	previewBytes, err := io.ReadAll(evi.Preview)
-	require.NoError(t, err)
-	require.Equal(t, mediaBytes, previewBytes, "Preview and Media content should be identical for codeblocks")
-	require.Equal(t, []byte(newContent), previewBytes)
-
-	updatedEvidence := getEvidenceByID(t, db, codeblockEvidence.ID)
-	require.Equal(t, updatedEvidence.ThumbImageKey, updatedEvidence.FullImageKey)
-	require.NotEqual(t, "", updatedEvidence.FullImageKey)
 }
 
 func validateEvidence(t *testing.T, expected FullEvidence, actual dtos.Evidence) {
@@ -373,39 +368,13 @@ func validateEvidenceSets(t *testing.T, dtoSet []dtos.Evidence, dbSet []FullEvid
 }
 
 func toPtrTagList(in []dtos.Tag) []*dtos.Tag {
-	rtn := make([]*dtos.Tag, len(in))
-
-	for i := range in {
-		rtn[i] = &in[i]
-	}
-
-	return rtn
+	return helpers.Map(in, helpers.Ptr[dtos.Tag])
 }
 
 func toRealEvidenceList(in []*dtos.Evidence) []dtos.Evidence {
-	rtn := make([]dtos.Evidence, len(in))
-
-	for i := range in {
-		rtn[i] = *in[i]
-	}
-
-	return rtn
-}
-
-func cloneEvidence(in models.Evidence) models.Evidence {
-	return models.Evidence{
-		ID:            in.ID,
-		UUID:          in.UUID,
-		OperationID:   in.OperationID,
-		OperatorID:    in.OperatorID,
-		Description:   in.Description,
-		ContentType:   in.ContentType,
-		FullImageKey:  in.FullImageKey,
-		ThumbImageKey: in.ThumbImageKey,
-		OccurredAt:    in.OccurredAt,
-		CreatedAt:     in.CreatedAt,
-		UpdatedAt:     in.UpdatedAt,
-	}
+	return helpers.Map(in, func(v *dtos.Evidence) dtos.Evidence {
+		return *v
+	})
 }
 
 func validateReadEvidenceOutput(t *testing.T, expected models.Evidence, actual *services.ReadEvidenceOutput) {
@@ -438,46 +407,45 @@ func validateInsertedEvidence(t *testing.T, evi *dtos.Evidence, src services.Cre
 }
 
 func TestMoveEvidence(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		startingOp := OpChamberOfSecrets
+		endingOp := OpSorcerersStone
+		sourceEvidence := EviPetrifiedHermione //shares tags between the two operations
 
-	startingOp := OpChamberOfSecrets
-	endingOp := OpSorcerersStone
-	sourceEvidence := EviPetrifiedHermione //shares tags between the two operations
+		input := services.MoveEvidenceInput{
+			SourceOperationSlug: startingOp.Slug,
+			TargetOperationSlug: endingOp.Slug,
+			EvidenceUUID:        sourceEvidence.UUID,
+		}
 
-	input := services.MoveEvidenceInput{
-		SourceOperationSlug: startingOp.Slug,
-		TargetOperationSlug: endingOp.Slug,
-		EvidenceUUID:        sourceEvidence.UUID,
-	}
+		// scenario 1: User present in both, cannot write dst [should fail]
+		ctx := contextForUser(UserHermione, db)
+		err := services.MoveEvidence(ctx, db, input)
+		require.Error(t, err)
 
-	// scenario 1: User present in both, cannot write dst [should fail]
-	ctx := contextForUser(UserHermione, db)
-	err := services.MoveEvidence(ctx, db, input)
-	require.Error(t, err)
+		// scenario 2: User present in both, cannot write src [should fail]
+		ctx = contextForUser(UserSeamus, db)
+		err = services.MoveEvidence(ctx, db, input)
+		require.Error(t, err)
 
-	// scenario 2: User present in both, cannot write src [should fail]
-	ctx = contextForUser(UserSeamus, db)
-	err = services.MoveEvidence(ctx, db, input)
-	require.Error(t, err)
+		// scenario 3: User present in src, cannot write dst [should fail]
+		ctx = contextForUser(UserGinny, db)
+		err = services.MoveEvidence(ctx, db, input)
+		require.Error(t, err)
 
-	// scenario 3: User present in src, cannot write dst [should fail]
-	ctx = contextForUser(UserGinny, db)
-	err = services.MoveEvidence(ctx, db, input)
-	require.Error(t, err)
+		// scenario 4: User present in dst, cannot write src [should fail]
+		ctx = contextForUser(UserNeville, db)
+		err = services.MoveEvidence(ctx, db, input)
+		require.Error(t, err)
 
-	// scenario 4: User present in dst, cannot write src [should fail]
-	ctx = contextForUser(UserNeville, db)
-	err = services.MoveEvidence(ctx, db, input)
-	require.Error(t, err)
+		// // scenario 5: User present in both, cannot write to both [should succeed]
+		ctx = contextForUser(UserHarry, db)
+		err = services.MoveEvidence(ctx, db, input)
+		require.NoError(t, err)
 
-	// // scenario 5: User present in both, cannot write to both [should succeed]
-	ctx = contextForUser(UserHarry, db)
-	err = services.MoveEvidence(ctx, db, input)
-	require.NoError(t, err)
-
-	updatedEvidence := getEvidenceByUUID(t, db, sourceEvidence.UUID)
-	require.Equal(t, updatedEvidence.OperationID, endingOp.ID)
-	associatedTags := getTagIDsFromEvidenceID(t, db, updatedEvidence.ID)
-	require.Equal(t, sorted(associatedTags), sorted([]int64{CommonTagWhoSS.ID, CommonTagWhatSS.ID}))
+		updatedEvidence := getEvidenceByUUID(t, db, sourceEvidence.UUID)
+		require.Equal(t, updatedEvidence.OperationID, endingOp.ID)
+		associatedTags := getTagIDsFromEvidenceID(t, db, updatedEvidence.ID)
+		require.Equal(t, sorted(associatedTags), sorted([]int64{CommonTagWhoSS.ID, CommonTagWhatSS.ID}))
+	})
 }

--- a/backend/services/finding_category_test.go
+++ b/backend/services/finding_category_test.go
@@ -8,158 +8,157 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/models"
 	"github.com/theparanoids/ashirt-server/backend/services"
 )
 
 func TestCreateFindingCategory(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	// verify non-admin cannot add a new category
-	newCategory := "Bogus Category"
-	_, err := services.CreateFindingCategory(ctx, db, newCategory)
-	require.Error(t, err)
+		// verify non-admin cannot add a new category
+		newCategory := "Bogus Category"
+		_, err := services.CreateFindingCategory(ctx, db, newCategory)
+		require.Error(t, err)
 
-	// verify that admins can create new categories
-	ctx = contextForUser(UserDumbledore, db)
-	newCategory = "Legitimate Category"
-	createdFindingCategory, err := services.CreateFindingCategory(ctx, db, newCategory)
-	require.NoError(t, err)
-	require.Equal(t, newCategory, createdFindingCategory.Category)
+		// verify that admins can create new categories
+		ctx = contextForUser(UserDumbledore, db)
+		newCategory = "Legitimate Category"
+		createdFindingCategory, err := services.CreateFindingCategory(ctx, db, newCategory)
+		require.NoError(t, err)
+		require.Equal(t, newCategory, createdFindingCategory.Category)
 
-	// verify that categories cannot be duplicated
-	_, err = services.CreateFindingCategory(ctx, db, newCategory)
-	require.Error(t, err)
+		// verify that categories cannot be duplicated
+		_, err = services.CreateFindingCategory(ctx, db, newCategory)
+		require.Error(t, err)
+	})
 }
 
 func TestDeleteFindingCategory(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
-	deleteTargetCategory := ProductFindingCategory
-	restoreTargetCategory := DeletedCategory
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserRon, db)
+		deleteTargetCategory := ProductFindingCategory
+		restoreTargetCategory := DeletedCategory
 
-	deleteInput := services.DeleteFindingCategoryInput{
-		DoDelete:          true,
-		FindingCategoryID: deleteTargetCategory.ID,
-	}
-
-	// verify that normal users cannot delete categories
-	err := services.DeleteFindingCategory(ctx, db, deleteInput)
-	require.Error(t, err)
-
-	// verify that admins can delete categories
-	ctx = contextForUser(UserDumbledore, db)
-	err = services.DeleteFindingCategory(ctx, db, deleteInput)
-	require.NoError(t, err)
-
-	// verify that admins can restore categories
-	restoreInput := services.DeleteFindingCategoryInput{
-		DoDelete:          false,
-		FindingCategoryID: restoreTargetCategory.ID,
-	}
-
-	// verify that categories cannot be duplicated
-	err = services.DeleteFindingCategory(ctx, db, restoreInput)
-	require.NoError(t, err)
-
-	// check list results
-	updatedFindingList := make([]models.FindingCategory, 0)
-	for _, item := range HarryPotterSeedData.FindingCategories {
-		if item == deleteTargetCategory {
-			deletedTime := GetInternalClock().Now()
-			deleteTargetCategory.DeletedAt = &deletedTime
-			updatedFindingList = append(updatedFindingList, deleteTargetCategory)
-		} else if item == restoreTargetCategory {
-			restoreTargetCategory.DeletedAt = nil
-			updatedFindingList = append(updatedFindingList, restoreTargetCategory)
-		} else {
-			updatedFindingList = append(updatedFindingList, item)
+		deleteInput := services.DeleteFindingCategoryInput{
+			DoDelete:          true,
+			FindingCategoryID: deleteTargetCategory.ID,
 		}
-	}
 
-	allCategories, err := services.ListFindingCategories(ctx, db, true)
-	require.NoError(t, err)
-	coercedCateories, ok := allCategories.([]*dtos.FindingCategory)
-	require.True(t, ok)
+		// verify that normal users cannot delete categories
+		err := services.DeleteFindingCategory(ctx, db, deleteInput)
+		require.Error(t, err)
 
-	requireFindingCategoriesAlign(t, updatedFindingList, coercedCateories)
+		// verify that admins can delete categories
+		ctx = contextForUser(UserDumbledore, db)
+		err = services.DeleteFindingCategory(ctx, db, deleteInput)
+		require.NoError(t, err)
+
+		// verify that admins can restore categories
+		restoreInput := services.DeleteFindingCategoryInput{
+			DoDelete:          false,
+			FindingCategoryID: restoreTargetCategory.ID,
+		}
+
+		// verify that categories cannot be duplicated
+		err = services.DeleteFindingCategory(ctx, db, restoreInput)
+		require.NoError(t, err)
+
+		// check list results
+		updatedFindingList := make([]models.FindingCategory, 0)
+		for _, item := range seed.FindingCategories {
+			if item == deleteTargetCategory {
+				deletedTime := GetInternalClock().Now()
+				deleteTargetCategory.DeletedAt = &deletedTime
+				updatedFindingList = append(updatedFindingList, deleteTargetCategory)
+			} else if item == restoreTargetCategory {
+				restoreTargetCategory.DeletedAt = nil
+				updatedFindingList = append(updatedFindingList, restoreTargetCategory)
+			} else {
+				updatedFindingList = append(updatedFindingList, item)
+			}
+		}
+
+		allCategories, err := services.ListFindingCategories(ctx, db, true)
+		require.NoError(t, err)
+		coercedCateories, ok := allCategories.([]*dtos.FindingCategory)
+		require.True(t, ok)
+
+		requireFindingCategoriesAlign(t, updatedFindingList, coercedCateories)
+	})
 }
 
 func TestListFindingsCategories(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	normalUserCtx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		normalUserCtx := contextForUser(UserRon, db)
 
-	// set up some helpers
-	seedCategories := HarryPotterSeedData.FindingCategories
-	activeSeedCategories := make([]models.FindingCategory, 0)
+		// set up some helpers
+		seedCategories := seed.FindingCategories
+		activeSeedCategories := make([]models.FindingCategory, 0)
 
-	for _, cat := range seedCategories {
-		if cat.DeletedAt == nil {
-			activeSeedCategories = append(activeSeedCategories, cat)
+		for _, cat := range seedCategories {
+			if cat.DeletedAt == nil {
+				activeSeedCategories = append(activeSeedCategories, cat)
+			}
 		}
-	}
 
-	activeCategories, err := services.ListFindingCategories(normalUserCtx, db, false)
-	require.NoError(t, err)
+		activeCategories, err := services.ListFindingCategories(normalUserCtx, db, false)
+		require.NoError(t, err)
 
-	// verify all active categories exist (size is the same, and each active entry in seed)
-	coercedCateories, ok := activeCategories.([]*dtos.FindingCategory)
-	require.True(t, ok)
-	requireFindingCategoriesAlign(t, activeSeedCategories, coercedCateories)
+		// verify all active categories exist (size is the same, and each active entry in seed)
+		coercedCateories, ok := activeCategories.([]*dtos.FindingCategory)
+		require.True(t, ok)
+		requireFindingCategoriesAlign(t, activeSeedCategories, coercedCateories)
 
-	allCategories, err := services.ListFindingCategories(normalUserCtx, db, true)
-	require.NoError(t, err)
+		allCategories, err := services.ListFindingCategories(normalUserCtx, db, true)
+		require.NoError(t, err)
 
-	// verify all categories exist (size is the same, and each entry exists in seed)
-	coercedCateories, ok = allCategories.([]*dtos.FindingCategory)
-	require.True(t, ok)
-	requireFindingCategoriesAlign(t, seedCategories, coercedCateories)
+		// verify all categories exist (size is the same, and each entry exists in seed)
+		coercedCateories, ok = allCategories.([]*dtos.FindingCategory)
+		require.True(t, ok)
+		requireFindingCategoriesAlign(t, seedCategories, coercedCateories)
+	})
 }
 
 func TestUpdateFindingCategory(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	targetCategory := ProductFindingCategory
+		targetCategory := ProductFindingCategory
 
-	// verify non-admin cannot add a new category
-	i := services.UpdateFindingCategoryInput{
-		Category: "My new category",
-		ID:       targetCategory.ID,
-	}
-	err := services.UpdateFindingCategory(ctx, db, i)
-	require.Error(t, err)
-
-	// verify that admins can create new categories
-	ctx = contextForUser(UserDumbledore, db)
-	err = services.UpdateFindingCategory(ctx, db, i)
-	require.NoError(t, err)
-
-	updatedFindingList := make([]models.FindingCategory, 0)
-	for _, item := range HarryPotterSeedData.FindingCategories {
-		if item == targetCategory {
-			updatedCategory := targetCategory
-			updatedCategory.Category = i.Category
-			updatedFindingList = append(updatedFindingList, updatedCategory)
-		} else {
-			updatedFindingList = append(updatedFindingList, item)
+		// verify non-admin cannot add a new category
+		i := services.UpdateFindingCategoryInput{
+			Category: "My new category",
+			ID:       targetCategory.ID,
 		}
-	}
+		err := services.UpdateFindingCategory(ctx, db, i)
+		require.Error(t, err)
 
-	allCategories, err := services.ListFindingCategories(ctx, db, true)
-	require.NoError(t, err)
-	coercedCateories, ok := allCategories.([]*dtos.FindingCategory)
-	require.True(t, ok)
+		// verify that admins can create new categories
+		ctx = contextForUser(UserDumbledore, db)
+		err = services.UpdateFindingCategory(ctx, db, i)
+		require.NoError(t, err)
 
-	requireFindingCategoriesAlign(t, updatedFindingList, coercedCateories)
+		updatedFindingList := make([]models.FindingCategory, 0)
+		for _, item := range seed.FindingCategories {
+			if item == targetCategory {
+				updatedCategory := targetCategory
+				updatedCategory.Category = i.Category
+				updatedFindingList = append(updatedFindingList, updatedCategory)
+			} else {
+				updatedFindingList = append(updatedFindingList, item)
+			}
+		}
+
+		allCategories, err := services.ListFindingCategories(ctx, db, true)
+		require.NoError(t, err)
+		coercedCateories, ok := allCategories.([]*dtos.FindingCategory)
+		require.True(t, ok)
+
+		requireFindingCategoriesAlign(t, updatedFindingList, coercedCateories)
+	})
 }
 
 func requireFindingCategoriesAlign(t *testing.T, modelList []models.FindingCategory, dtoList []*dtos.FindingCategory) {

--- a/backend/services/operation_role_test.go
+++ b/backend/services/operation_role_test.go
@@ -15,58 +15,58 @@ import (
 )
 
 func TestSetUserOperationRole(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
-	targetUser := UserHarry
-	targetRole := policy.OperationRoleRead
-	input := services.SetUserOperationRoleInput{
-		OperationSlug: masterOp.Slug,
-		UserSlug:      targetUser.Slug,
-		Role:          targetRole,
-	}
+		masterOp := OpChamberOfSecrets
+		targetUser := UserHarry
+		targetRole := policy.OperationRoleRead
+		input := services.SetUserOperationRoleInput{
+			OperationSlug: masterOp.Slug,
+			UserSlug:      targetUser.Slug,
+			Role:          targetRole,
+		}
 
-	initialRole := HarryPotterSeedData.UserRoleForOp(targetUser, masterOp)
-	require.NotContains(t, []policy.OperationRole{targetRole, ""}, initialRole, "Test user should both have a role, but not have the role we want to use")
+		initialRole := seed.UserRoleForOp(targetUser, masterOp)
+		require.NotContains(t, []policy.OperationRole{targetRole, ""}, initialRole, "Test user should both have a role, but not have the role we want to use")
 
-	err := services.SetUserOperationRole(ctx, db, input)
-	require.NoError(t, err)
+		err := services.SetUserOperationRole(ctx, db, input)
+		require.NoError(t, err)
 
-	getDBRole := func() (string, error) {
-		var newRole string
-		err := db.Get(&newRole, sq.Select("role").
-			From("user_operation_permissions").
-			Where(sq.Eq{"operation_id": masterOp.ID, "user_id": targetUser.ID}))
-		return newRole, err
-	}
-	newRole, err := getDBRole()
-	require.NoError(t, err)
-	require.Equal(t, string(targetRole), newRole)
+		getDBRole := func() (string, error) {
+			var newRole string
+			err := db.Get(&newRole, sq.Select("role").
+				From("user_operation_permissions").
+				Where(sq.Eq{"operation_id": masterOp.ID, "user_id": targetUser.ID}))
+			return newRole, err
+		}
+		newRole, err := getDBRole()
+		require.NoError(t, err)
+		require.Equal(t, string(targetRole), newRole)
 
-	input = services.SetUserOperationRoleInput{
-		OperationSlug: masterOp.Slug,
-		UserSlug:      targetUser.Slug,
-		Role:          "",
-	}
+		input = services.SetUserOperationRoleInput{
+			OperationSlug: masterOp.Slug,
+			UserSlug:      targetUser.Slug,
+			Role:          "",
+		}
 
-	err = services.SetUserOperationRole(ctx, db, input)
-	require.NoError(t, err)
+		err = services.SetUserOperationRole(ctx, db, input)
+		require.NoError(t, err)
 
-	_, err = getDBRole()
-	require.True(t, database.IsEmptyResultSetError(err))
+		_, err = getDBRole()
+		require.True(t, database.IsEmptyResultSetError(err))
 
-	targetRole = policy.OperationRoleAdmin
-	input = services.SetUserOperationRoleInput{
-		OperationSlug: masterOp.Slug,
-		UserSlug:      targetUser.Slug,
-		Role:          targetRole,
-	}
-	err = services.SetUserOperationRole(ctx, db, input)
-	require.NoError(t, err)
+		targetRole = policy.OperationRoleAdmin
+		input = services.SetUserOperationRoleInput{
+			OperationSlug: masterOp.Slug,
+			UserSlug:      targetUser.Slug,
+			Role:          targetRole,
+		}
+		err = services.SetUserOperationRole(ctx, db, input)
+		require.NoError(t, err)
 
-	newRole, err = getDBRole()
-	require.NoError(t, err)
-	require.Equal(t, string(targetRole), newRole)
+		newRole, err = getDBRole()
+		require.NoError(t, err)
+		require.Equal(t, string(targetRole), newRole)
+	})
 }

--- a/backend/services/operations_test.go
+++ b/backend/services/operations_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/models"
 	"github.com/theparanoids/ashirt-server/backend/policy"
@@ -16,102 +17,140 @@ import (
 )
 
 func TestCreateOperation(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	// verify slug name is invalid
-	i := services.CreateOperationInput{
-		Slug:    "???",
-		OwnerID: UserRon.ID,
-		Name:    "Ron's Op",
-	}
-	_, err := services.CreateOperation(ctx, db, i)
-	require.Error(t, err)
-
-	// verify proper creation of a new operation
-	i = services.CreateOperationInput{
-		Slug:    "rop",
-		OwnerID: UserRon.ID,
-		Name:    "Ron's Op",
-	}
-	createdOp, err := services.CreateOperation(ctx, db, i)
-	require.NoError(t, err)
-	fullOp := getOperationFromSlug(t, db, createdOp.Slug)
-
-	require.NotEqual(t, 0, fullOp.ID)
-	require.Equal(t, i.Name, fullOp.Name)
-	require.Equal(t, models.OperationStatusPlanning, fullOp.Status, "status should default to 'Planning'")
-
-	attachedUsers := getUserRolesForOperationByOperationID(t, db, fullOp.ID)
-	require.Equal(t, 1, len(attachedUsers))
-	require.Equal(t, policy.OperationRoleAdmin, attachedUsers[0].Role, "Creator of operation should have admin role for that operation")
-	require.Equal(t, i.OwnerID, attachedUsers[0].UserID)
-
-	attachedTags := getTagFromOperationID(t, db, fullOp.ID)
-	defaultTags := getDefaultTags(t, db)
-	expectedTags := make([]models.Tag, len(defaultTags))
-	for idx, tag := range defaultTags {
-		expectedTags[idx].ColorName = tag.ColorName
-		expectedTags[idx].Name = tag.Name
-	}
-
-	for _, tag := range attachedTags {
-		foundIndex := -1
-		for idx, eTag := range expectedTags {
-			if tag.Name == eTag.Name && tag.ColorName == eTag.ColorName {
-				foundIndex = idx
-			}
+		// verify slug name is invalid
+		i := services.CreateOperationInput{
+			Slug:    "???",
+			OwnerID: UserRon.ID,
+			Name:    "Ron's Op",
 		}
-		require.NotEqual(t, -1, foundIndex, "Each of the created tags must be from default tags")
-		expectedTags = append(expectedTags[:foundIndex], expectedTags[foundIndex+1:]...)
-	}
-	require.Empty(t, expectedTags, "All of the expected tags must be used")
+		_, err := services.CreateOperation(ctx, db, i)
+		require.Error(t, err)
+
+		// verify proper creation of a new operation
+		i = services.CreateOperationInput{
+			Slug:    "rop",
+			OwnerID: UserRon.ID,
+			Name:    "Ron's Op",
+		}
+		createdOp, err := services.CreateOperation(ctx, db, i)
+		require.NoError(t, err)
+		fullOp := getOperationFromSlug(t, db, createdOp.Slug)
+
+		require.NotEqual(t, 0, fullOp.ID)
+		require.Equal(t, i.Name, fullOp.Name)
+		require.Equal(t, models.OperationStatusPlanning, fullOp.Status, "status should default to 'Planning'")
+
+		attachedUsers := getUserRolesForOperationByOperationID(t, db, fullOp.ID)
+		require.Equal(t, 1, len(attachedUsers))
+		require.Equal(t, policy.OperationRoleAdmin, attachedUsers[0].Role, "Creator of operation should have admin role for that operation")
+		require.Equal(t, i.OwnerID, attachedUsers[0].UserID)
+
+		attachedTags := getTagFromOperationID(t, db, fullOp.ID)
+		defaultTags := getDefaultTags(t, db)
+		expectedTags := make([]models.Tag, len(defaultTags))
+		for idx, tag := range defaultTags {
+			expectedTags[idx].ColorName = tag.ColorName
+			expectedTags[idx].Name = tag.Name
+		}
+
+		for _, tag := range attachedTags {
+			foundIndex := -1
+			for idx, eTag := range expectedTags {
+				if tag.Name == eTag.Name && tag.ColorName == eTag.ColorName {
+					foundIndex = idx
+				}
+			}
+			require.NotEqual(t, -1, foundIndex, "Each of the created tags must be from default tags")
+			expectedTags = append(expectedTags[:foundIndex], expectedTags[foundIndex+1:]...)
+		}
+		require.Empty(t, expectedTags, "All of the expected tags must be used")
+	})
 }
 
 func TestDeleteOperation(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserHarry, db)
-	memStore := createPopulatedMemStore(HarryPotterSeedData)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserHarry, db)
+		memStore := createPopulatedMemStore(seed)
 
-	masterOp := OpChamberOfSecrets
-	originalEvidence := getEvidenceForOperation(t, db, masterOp.ID)
+		masterOp := OpChamberOfSecrets
+		originalEvidence := getEvidenceForOperation(t, db, masterOp.ID)
 
-	// Verify that non-admins cannot delete
-	err := services.DeleteOperation(ctx, db, memStore, masterOp.Slug)
-	require.Error(t, err)
-
-	// Verify admins can delete
-	ctx = contextForUser(UserRon, db)
-	err = services.DeleteOperation(ctx, db, memStore, masterOp.Slug)
-	require.NoError(t, err)
-	// ensure content was removed
-	for _, evi := range originalEvidence {
-		_, err = memStore.Read(evi.FullImageKey)
+		// Verify that non-admins cannot delete
+		err := services.DeleteOperation(ctx, db, memStore, masterOp.Slug)
 		require.Error(t, err)
-		_, err = memStore.Read(evi.ThumbImageKey)
-		require.Error(t, err)
-	}
-	var dbOp models.Operation
-	err = db.Get(&dbOp, sq.Select("*").From("operations").Where(sq.Eq{"id": masterOp.ID}))
-	// assuming that if this row was deleted, then all other rows must have been deleted (via foreign key constraint)
-	require.Error(t, err)
 
-	// Verify Super admins can delete
-	// TODO
+		// Verify admins can delete
+		ctx = contextForUser(UserRon, db)
+		err = services.DeleteOperation(ctx, db, memStore, masterOp.Slug)
+		require.NoError(t, err)
+		// ensure content was removed
+		for _, evi := range originalEvidence {
+			_, err = memStore.Read(evi.FullImageKey)
+			require.Error(t, err)
+			_, err = memStore.Read(evi.ThumbImageKey)
+			require.Error(t, err)
+		}
+		var dbOp models.Operation
+		err = db.Get(&dbOp, sq.Select("*").From("operations").Where(sq.Eq{"id": masterOp.ID}))
+		// assuming that if this row was deleted, then all other rows must have been deleted (via foreign key constraint)
+		require.Error(t, err)
+
+		// Verify Super admins can delete
+		// TODO
+	})
 }
 
 func TestListOperations(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		validateOperationList := func(receivedOps []*dtos.Operation, expectedOps []models.Operation) {
+			for _, op := range receivedOps {
+				var expected *models.Operation = nil
+				for _, fOp := range expectedOps {
+					if fOp.Slug == op.Slug {
+						expected = &fOp
+						break
+					}
+				}
+				require.NotNil(t, expected, "Result should have matching value")
+				validateOp(t, *expected, op)
+			}
+		}
 
-	validateOperationList := func(receivedOps []*dtos.Operation, expectedOps []models.Operation) {
-		for _, op := range receivedOps {
+		normalUser := UserRon
+		expectedOps := getOperationsForUser(t, db, normalUser.ID)
+
+		ops, err := services.ListOperations(contextForUser(normalUser, db), db)
+		require.NoError(t, err)
+		require.Equal(t, len(ops), len(expectedOps))
+		validateOperationList(ops, expectedOps)
+
+		// validate headless users
+		headlessUser := UserHeadlessNick
+		fullOps := getOperations(t, db)
+
+		ops, err = services.ListOperations(contextForUser(headlessUser, db), db)
+		require.NoError(t, err)
+		require.Equal(t, len(ops), len(fullOps))
+		validateOperationList(ops, fullOps)
+	})
+}
+
+func TestListOperationsForAdmin(t *testing.T) {
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserDumbledore, db)
+
+		fullOps := getOperations(t, db)
+		require.NotEqual(t, len(fullOps), 0, "Some number of operations should exist")
+
+		ops, err := services.ListOperationsForAdmin(ctx, db)
+		require.NoError(t, err)
+		require.Equal(t, len(ops), len(fullOps))
+		for _, op := range ops {
 			var expected *models.Operation = nil
-			for _, fOp := range expectedOps {
+			for _, fOp := range fullOps {
 				if fOp.Slug == op.Slug {
 					expected = &fOp
 					break
@@ -120,54 +159,13 @@ func TestListOperations(t *testing.T) {
 			require.NotNil(t, expected, "Result should have matching value")
 			validateOp(t, *expected, op)
 		}
-	}
 
-	normalUser := UserRon
-	expectedOps := getOperationsForUser(t, db, normalUser.ID)
-
-	ops, err := services.ListOperations(contextForUser(normalUser, db), db)
-	require.NoError(t, err)
-	require.Equal(t, len(ops), len(expectedOps))
-	validateOperationList(ops, expectedOps)
-
-	// validate headless users
-	headlessUser := UserHeadlessNick
-	fullOps := getOperations(t, db)
-
-	ops, err = services.ListOperations(contextForUser(headlessUser, db), db)
-	require.NoError(t, err)
-	require.Equal(t, len(ops), len(fullOps))
-	validateOperationList(ops, fullOps)
-}
-
-func TestListOperationsForAdmin(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserDumbledore, db)
-
-	fullOps := getOperations(t, db)
-	require.NotEqual(t, len(fullOps), 0, "Some number of operations should exist")
-
-	ops, err := services.ListOperationsForAdmin(ctx, db)
-	require.NoError(t, err)
-	require.Equal(t, len(ops), len(fullOps))
-	for _, op := range ops {
-		var expected *models.Operation = nil
-		for _, fOp := range fullOps {
-			if fOp.Slug == op.Slug {
-				expected = &fOp
-				break
-			}
-		}
-		require.NotNil(t, expected, "Result should have matching value")
-		validateOp(t, *expected, op)
-	}
-
-	// verify non admins don't have access
-	ctx = contextForUser(UserDraco, db)
-	_, err = services.ListOperationsForAdmin(ctx, db)
-	require.Error(t, err)
-	require.Equal(t, "Requesting user is not an admin", err.Error())
+		// verify non admins don't have access
+		ctx = contextForUser(UserDraco, db)
+		_, err = services.ListOperationsForAdmin(ctx, db)
+		require.Error(t, err)
+		require.Equal(t, "Requesting user is not an admin", err.Error())
+	})
 }
 
 func TestSanitizeOperationSlug(t *testing.T) {
@@ -179,41 +177,41 @@ func TestSanitizeOperationSlug(t *testing.T) {
 }
 
 func TestUpdateOperation(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	// tests for common fields
-	masterOp := OpChamberOfSecrets
-	input := services.UpdateOperationInput{
-		OperationSlug: masterOp.Slug,
-		Name:          "New Name",
-		Status:        models.OperationStatusComplete,
-	}
-	require.NotEqual(t, masterOp.Status, input.Status)
+		// tests for common fields
+		masterOp := OpChamberOfSecrets
+		input := services.UpdateOperationInput{
+			OperationSlug: masterOp.Slug,
+			Name:          "New Name",
+			Status:        models.OperationStatusComplete,
+		}
+		require.NotEqual(t, masterOp.Status, input.Status)
 
-	err := services.UpdateOperation(ctx, db, input)
-	require.NoError(t, err)
-	updatedOperation, err := services.ReadOperation(ctx, db, masterOp.Slug)
-	require.NoError(t, err)
-	require.Equal(t, input.Name, updatedOperation.Name)
-	require.Equal(t, input.Status, updatedOperation.Status)
+		err := services.UpdateOperation(ctx, db, input)
+		require.NoError(t, err)
+		updatedOperation, err := services.ReadOperation(ctx, db, masterOp.Slug)
+		require.NoError(t, err)
+		require.Equal(t, input.Name, updatedOperation.Name)
+		require.Equal(t, input.Status, updatedOperation.Status)
+	})
 }
 
 func TestReadOperation(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
+		masterOp := OpChamberOfSecrets
 
-	retrievedOp, err := services.ReadOperation(ctx, db, masterOp.Slug)
-	require.NoError(t, err)
+		retrievedOp, err := services.ReadOperation(ctx, db, masterOp.Slug)
+		require.NoError(t, err)
 
-	require.Equal(t, masterOp.Slug, retrievedOp.Slug)
-	require.Equal(t, masterOp.Name, retrievedOp.Name)
-	require.Equal(t, masterOp.Status, retrievedOp.Status)
-	require.Equal(t, len(HarryPotterSeedData.UsersForOp(masterOp)), retrievedOp.NumUsers)
+		require.Equal(t, masterOp.Slug, retrievedOp.Slug)
+		require.Equal(t, masterOp.Name, retrievedOp.Name)
+		require.Equal(t, masterOp.Status, retrievedOp.Status)
+		require.Equal(t, len(seed.UsersForOp(masterOp)), retrievedOp.NumUsers)
+	})
 }
 
 func validateOp(t *testing.T, expected models.Operation, actual *dtos.Operation) {

--- a/backend/services/queries_test.go
+++ b/backend/services/queries_test.go
@@ -7,131 +7,132 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/ashirt-server/backend/models"
 	"github.com/theparanoids/ashirt-server/backend/services"
 )
 
 func TestCreateQuery(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	op := OpChamberOfSecrets
-	i := services.CreateQueryInput{
-		OperationSlug: op.Slug,
-		Name:          "Evidence By author",
-		Query:         "<query goes here>",
-		Type:          "findings",
-	}
-	createdQuery, err := services.CreateQuery(ctx, db, i)
-	require.NoError(t, err)
-	fullQuery := getQueryByID(t, db, createdQuery.ID)
-	require.Equal(t, i.Name, fullQuery.Name)
-	require.Equal(t, i.Type, fullQuery.Type)
-	require.Equal(t, i.Query, fullQuery.Query)
+		op := OpChamberOfSecrets
+		i := services.CreateQueryInput{
+			OperationSlug: op.Slug,
+			Name:          "Evidence By author",
+			Query:         "<query goes here>",
+			Type:          "findings",
+		}
+		createdQuery, err := services.CreateQuery(ctx, db, i)
+		require.NoError(t, err)
+		fullQuery := getQueryByID(t, db, createdQuery.ID)
+		require.Equal(t, i.Name, fullQuery.Name)
+		require.Equal(t, i.Type, fullQuery.Type)
+		require.Equal(t, i.Query, fullQuery.Query)
+	})
 }
 
 func TestDeleteQuery(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	i := services.DeleteQueryInput{
-		OperationSlug: OpChamberOfSecrets.Slug,
-		ID:            QuerySalazarsHier.ID,
-	}
+		i := services.DeleteQueryInput{
+			OperationSlug: OpChamberOfSecrets.Slug,
+			ID:            QuerySalazarsHier.ID,
+		}
 
-	getQueryCount := makeDBRowCounter(t, db, "queries", "id=?", i.ID)
-	require.Equal(t, int64(1), getQueryCount(), "Database should have item to delete")
+		getQueryCount := makeDBRowCounter(t, db, "queries", "id=?", i.ID)
+		require.Equal(t, int64(1), getQueryCount(), "Database should have item to delete")
 
-	err := services.DeleteQuery(ctx, db, i)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), getQueryCount(), "Database should have deleted the item")
+		err := services.DeleteQuery(ctx, db, i)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), getQueryCount(), "Database should have deleted the item")
+	})
 }
 
 func TestListQueriesForOperation(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
-	allQueries := getQueriesForOperationID(t, db, masterOp.ID)
-	require.NotEqual(t, len(allQueries), 0, "Some number of queries should exist")
+		masterOp := OpChamberOfSecrets
+		allQueries := getQueriesForOperationID(t, db, masterOp.ID)
+		require.NotEqual(t, len(allQueries), 0, "Some number of queries should exist")
 
-	foundQueries, err := services.ListQueriesForOperation(ctx, db, masterOp.Slug)
-	require.NoError(t, err)
-	require.Equal(t, len(foundQueries), len(allQueries))
-	validateQuerySets(t, foundQueries, allQueries, validateQuery)
+		foundQueries, err := services.ListQueriesForOperation(ctx, db, masterOp.Slug)
+		require.NoError(t, err)
+		require.Equal(t, len(foundQueries), len(allQueries))
+		validateQuerySets(t, foundQueries, allQueries, validateQuery)
+	})
 }
 
 func TestUpdateQuery(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
-	masterQuery := QuerySalazarsHier
-	input := services.UpdateQueryInput{
-		OperationSlug: masterOp.Slug,
-		ID:            masterQuery.ID,
-		Name:          "New Name",
-		Query:         "New Query",
-	}
+		masterOp := OpChamberOfSecrets
+		masterQuery := QuerySalazarsHier
+		input := services.UpdateQueryInput{
+			OperationSlug: masterOp.Slug,
+			ID:            masterQuery.ID,
+			Name:          "New Name",
+			Query:         "New Query",
+		}
 
-	err := services.UpdateQuery(ctx, db, input)
-	require.NoError(t, err)
+		err := services.UpdateQuery(ctx, db, input)
+		require.NoError(t, err)
 
-	updatedQuery := getQueryByID(t, db, masterQuery.ID)
+		updatedQuery := getQueryByID(t, db, masterQuery.ID)
 
-	require.NoError(t, err)
-	require.Equal(t, input.Name, updatedQuery.Name)
-	require.Equal(t, input.Query, updatedQuery.Query)
+		require.NoError(t, err)
+		require.Equal(t, input.Name, updatedQuery.Name)
+		require.Equal(t, input.Query, updatedQuery.Query)
+	})
 }
 
 func TestUpsertQuery(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	user := UserRon
-	ctx := contextForUser(user, db)
-	op := OpChamberOfSecrets
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		user := UserRon
+		ctx := contextForUser(user, db)
+		op := OpChamberOfSecrets
 
-	checkQueryData := func(i services.UpsertQueryInput, dbModel models.Query) {
-		require.Equal(t, i.Name, dbModel.Name)
-		require.Equal(t, i.Type, dbModel.Type)
-		require.Equal(t, i.Query, dbModel.Query)
-	}
+		checkQueryData := func(i services.UpsertQueryInput, dbModel models.Query) {
+			require.Equal(t, i.Name, dbModel.Name)
+			require.Equal(t, i.Type, dbModel.Type)
+			require.Equal(t, i.Query, dbModel.Query)
+		}
 
-	i := services.UpsertQueryInput{
-		CreateQueryInput: services.CreateQueryInput{
-			OperationSlug: op.Slug,
-			Name:          "Ron's amazing query",
-			Query:         "I can sepll!",
-			Type:          "evidence",
-		},
-		ReplaceName: false, // initial value doesn't matter
-	}
-	createdQuery, err := services.UpsertQuery(ctx, db, i)
-	require.NoError(t, err)
-	fullQuery := getQueryByID(t, db, createdQuery.ID)
-	checkQueryData(i, fullQuery)
+		i := services.UpsertQueryInput{
+			CreateQueryInput: services.CreateQueryInput{
+				OperationSlug: op.Slug,
+				Name:          "Ron's amazing query",
+				Query:         "I can sepll!",
+				Type:          "evidence",
+			},
+			ReplaceName: false, // initial value doesn't matter
+		}
+		createdQuery, err := services.UpsertQuery(ctx, db, i)
+		require.NoError(t, err)
+		fullQuery := getQueryByID(t, db, createdQuery.ID)
+		checkQueryData(i, fullQuery)
 
-	// Update the query
-	i.CreateQueryInput.Query = "I can spell!"
-	updatedQuery, err := services.UpsertQuery(ctx, db, i)
-	require.Equal(t, createdQuery.ID, updatedQuery.ID)
-	require.NoError(t, err)
-	fullUpdatedQuery := getQueryByID(t, db, updatedQuery.ID)
-	checkQueryData(i, fullUpdatedQuery)
+		// Update the query
+		i.CreateQueryInput.Query = "I can spell!"
+		updatedQuery, err := services.UpsertQuery(ctx, db, i)
+		require.Equal(t, createdQuery.ID, updatedQuery.ID)
+		require.NoError(t, err)
+		fullUpdatedQuery := getQueryByID(t, db, updatedQuery.ID)
+		checkQueryData(i, fullUpdatedQuery)
 
-	// update the name
-	i.CreateQueryInput.Name = "Ron's pretty good query"
-	i.ReplaceName = true
-	updatedQuery, err = services.UpsertQuery(ctx, db, i)
-	require.Equal(t, createdQuery.ID, updatedQuery.ID)
-	require.NoError(t, err)
-	fullUpdatedQuery = getQueryByID(t, db, updatedQuery.ID)
-	checkQueryData(i, fullUpdatedQuery)
+		// update the name
+		i.CreateQueryInput.Name = "Ron's pretty good query"
+		i.ReplaceName = true
+		updatedQuery, err = services.UpsertQuery(ctx, db, i)
+		require.Equal(t, createdQuery.ID, updatedQuery.ID)
+		require.NoError(t, err)
+		fullUpdatedQuery = getQueryByID(t, db, updatedQuery.ID)
+		checkQueryData(i, fullUpdatedQuery)
+	})
 }
 
 type queryValidator func(*testing.T, models.Query, *dtos.Query)

--- a/backend/services/seeding_rewrap_test.go
+++ b/backend/services/seeding_rewrap_test.go
@@ -81,6 +81,7 @@ func createPopulatedMemStore(seed TestSeedData) *contentstore.MemStore {
 var HarryPotterSeedData = TestSeedData{
 	seeding.HarryPotterSeedData,
 }
+var NoSeedData = TestSeedData {}
 
 var UserDumbledore = seeding.UserDumbledore
 var UserHarry = seeding.UserHarry

--- a/backend/services/service_pagination_helper_test.go
+++ b/backend/services/service_pagination_helper_test.go
@@ -47,20 +47,19 @@ func TestPaginationWrapData(t *testing.T) {
 }
 
 func TestPaginationSelect(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		// full page
+		checkTagSubset(t, services.Pagination{PageSize: 2, Page: 1}, db)
 
-	// full page
-	checkTagSubset(t, services.Pagination{PageSize: 2, Page: 1}, db)
+		// Second page
+		checkTagSubset(t, services.Pagination{PageSize: 2, Page: 2}, db)
 
-	// Second page
-	checkTagSubset(t, services.Pagination{PageSize: 2, Page: 2}, db)
+		// partial page
+		checkTagSubset(t, services.Pagination{PageSize: 100, Page: 1}, db)
 
-	// partial page
-	checkTagSubset(t, services.Pagination{PageSize: 100, Page: 1}, db)
-
-	// emptySet
-	checkTagSubset(t, services.Pagination{PageSize: 100, Page: 2}, db)
+		// emptySet
+		checkTagSubset(t, services.Pagination{PageSize: 100, Page: 2}, db)
+	})
 }
 
 func checkTagSubset(t *testing.T, p services.Pagination, db *database.Connection) {

--- a/backend/services/service_worker_test.go
+++ b/backend/services/service_worker_test.go
@@ -20,268 +20,265 @@ import (
 )
 
 func TestListServiceWorkers(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		tryList := func(u models.User) ([]*dtos.ServiceWorker, error) {
+			ctx := contextForUser(u, db)
+			return services.ListServiceWorker(ctx, db)
+		}
 
-	tryList := func(u models.User) ([]*dtos.ServiceWorker, error) {
-		ctx := contextForUser(u, db)
-		return services.ListServiceWorker(ctx, db)
-	}
+		// verify permissions
+		_, err := tryList(UserRon)
+		require.Error(t, err) // non-admin
 
-	// verify permissions
-	_, err := tryList(UserRon)
-	require.Error(t, err) // non-admin
-
-	// verify result
-	list, err := tryList(UserDumbledore)
-	require.NoError(t, err)
-	for _, worker := range list {
-		_, match := helpers.Find(HarryPotterSeedData.ServiceWorkers, func(w models.ServiceWorker) bool {
-			return w.ID == worker.ID
-		})
-		require.NotNil(t, match)
-		require.Equal(t, match.Name, worker.Name)
-		require.Equal(t, match.DeletedAt != nil, worker.Deleted)
-		require.JSONEq(t, match.Config, worker.Config)
-	}
+		// verify result
+		list, err := tryList(UserDumbledore)
+		require.NoError(t, err)
+		for _, worker := range list {
+			_, match := helpers.Find(seed.ServiceWorkers, func(w models.ServiceWorker) bool {
+				return w.ID == worker.ID
+			})
+			require.NotNil(t, match)
+			require.Equal(t, match.Name, worker.Name)
+			require.Equal(t, match.DeletedAt != nil, worker.Deleted)
+			require.JSONEq(t, match.Config, worker.Config)
+		}
+	})
 }
 
 func TestCreateServiceWorker(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		tryCreate := func(u models.User, input services.CreateServiceWorkerInput) error {
+			ctx := contextForUser(u, db)
+			return services.CreateServiceWorker(ctx, db, input)
+		}
 
-	tryCreate := func(u models.User, input services.CreateServiceWorkerInput) error {
-		ctx := contextForUser(u, db)
-		return services.CreateServiceWorker(ctx, db, input)
-	}
+		input := services.CreateServiceWorkerInput{
+			Name:   "IsAHorcrux",
+			Config: `{"type": "web", "version": 1, "url": "http://test:1234"}`,
+		}
 
-	input := services.CreateServiceWorkerInput{
-		Name:   "IsAHorcrux",
-		Config: `{"type": "web", "version": 1, "url": "http://test:1234"}`,
-	}
+		// verify permissions
+		require.Error(t, tryCreate(UserRon, input)) // non-admin
 
-	// verify permissions
-	require.Error(t, tryCreate(UserRon, input)) // non-admin
-
-	// verify result
-	require.NoError(t, tryCreate(UserDumbledore, input))
-	svc := getServiceWorkerByName(t, db, input.Name)
-	require.JSONEq(t, svc.Config, input.Config)
+		// verify result
+		require.NoError(t, tryCreate(UserDumbledore, input))
+		svc := getServiceWorkerByName(t, db, input.Name)
+		require.JSONEq(t, svc.Config, input.Config)
+	})
 }
 
 func TestUpdateServiceWorker(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		tryUpdate := func(u models.User, input services.UpdateServiceWorkerInput) error {
+			ctx := contextForUser(u, db)
+			return services.UpdateServiceWorker(ctx, db, input)
+		}
 
-	tryUpdate := func(u models.User, input services.UpdateServiceWorkerInput) error {
-		ctx := contextForUser(u, db)
-		return services.UpdateServiceWorker(ctx, db, input)
-	}
+		input := services.UpdateServiceWorkerInput{
+			ID:     DemoServiceWorker.ID,
+			Name:   "BetterWorker",
+			Config: `{"type": "web", "version": 1, "url": "http://test:1234"}`,
+		}
 
-	input := services.UpdateServiceWorkerInput{
-		ID:     DemoServiceWorker.ID,
-		Name:   "BetterWorker",
-		Config: `{"type": "web", "version": 1, "url": "http://test:1234"}`,
-	}
+		// verify permissions
+		require.Error(t, tryUpdate(UserRon, input)) // non-admin
 
-	// verify permissions
-	require.Error(t, tryUpdate(UserRon, input)) // non-admin
-
-	// verify result
-	require.NoError(t, tryUpdate(UserDumbledore, input))
-	svc := getServiceWorkerByID(t, db, input.ID)
-	require.JSONEq(t, svc.Config, input.Config)
+		// verify result
+		require.NoError(t, tryUpdate(UserDumbledore, input))
+		svc := getServiceWorkerByID(t, db, input.ID)
+		require.JSONEq(t, svc.Config, input.Config)
+	})
 }
 
 func TestDeleteServiceWorker(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		tryDelete := func(u models.User, input services.DeleteServiceWorkerInput) error {
+			ctx := contextForUser(u, db)
+			return services.DeleteServiceWorker(ctx, db, input)
+		}
 
-	tryDelete := func(u models.User, input services.DeleteServiceWorkerInput) error {
-		ctx := contextForUser(u, db)
-		return services.DeleteServiceWorker(ctx, db, input)
-	}
+		input := services.DeleteServiceWorkerInput{
+			ID:       DemoServiceWorker.ID,
+			DoDelete: true,
+		}
 
-	input := services.DeleteServiceWorkerInput{
-		ID:       DemoServiceWorker.ID,
-		DoDelete: true,
-	}
+		checkNilness := func(shouldBeNil bool) {
+			svc := getServiceWorkerByID(t, db, input.ID)
+			require.Equal(t, svc.DeletedAt == nil, shouldBeNil)
+		}
 
-	checkNilness := func(shouldBeNil bool) {
-		svc := getServiceWorkerByID(t, db, input.ID)
-		require.Equal(t, svc.DeletedAt == nil, shouldBeNil)
-	}
+		// verify pre-conditions
+		checkNilness(true)
 
-	// verify pre-conditions
-	checkNilness(true)
+		// verify permissions
+		require.Error(t, tryDelete(UserRon, input)) // non-admin
+		checkNilness(true)
 
-	// verify permissions
-	require.Error(t, tryDelete(UserRon, input)) // non-admin
-	checkNilness(true)
+		// verify delete result
+		require.NoError(t, tryDelete(UserDumbledore, input))
+		checkNilness(false)
 
-	// verify delete result
-	require.NoError(t, tryDelete(UserDumbledore, input))
-	checkNilness(false)
-
-	// verify restore result
-	input.DoDelete = false
-	require.NoError(t, tryDelete(UserDumbledore, input))
-	checkNilness(true)
+		// verify restore result
+		input.DoDelete = false
+		require.NoError(t, tryDelete(UserDumbledore, input))
+		checkNilness(true)
+	})
 }
 
 func TestTestServiceWorker(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	worker := DemoServiceWorker
-	wasCalled := false
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		worker := DemoServiceWorker
+		wasCalled := false
 
-	testSuccess := buildRequestMock(func(w *httptest.ResponseRecorder) {
-		wasCalled = true
-		w.WriteHeader(http.StatusOK)
-		w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "ok"}))
-	})
-
-	testFailure := buildRequestMock(func(w *httptest.ResponseRecorder) {
-		wasCalled = true
-		w.WriteHeader(http.StatusOK)
-		w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "error", Message: helpers.Ptr("oops")}))
-	})
-
-	tryTest := func(u models.User, id int64) (*dtos.ServiceWorkerTestOutput, error) {
-		ctx := contextForUser(u, db)
-		return services.TestServiceWorker(ctx, db, id)
-	}
-
-	// verify permissions
-	_, err := tryTest(UserRon, worker.ID)
-	require.Error(t, err) // non-admin
-
-	// verify result (success)
-	enhancementservices.SetWebRequestFunctionForWorker(worker.Name, &testSuccess)
-	out, err := tryTest(UserDumbledore, worker.ID)
-	require.NoError(t, err)
-	require.True(t, wasCalled)
-	require.Equal(t, worker.ID, out.ID)
-	require.Equal(t, worker.Name, out.Name)
-	require.True(t, out.Live)
-
-	// verify result (failure)
-	wasCalled = false // reset to un-called
-	enhancementservices.SetWebRequestFunctionForWorker(worker.Name, &testFailure)
-	out, err = tryTest(UserDumbledore, worker.ID)
-	require.NoError(t, err)
-	require.True(t, wasCalled)
-	require.Equal(t, worker.ID, out.ID)
-	require.Equal(t, worker.Name, out.Name)
-	require.False(t, out.Live)
-}
-
-func TestRunServiceWorker(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	singleWorker := DemoServiceWorker
-
-	// pre-test: create another worker
-	makeAWorker(t, db, "IsAHorcrux")
-	knownWorkersList := requireNumberOfWorkers(t, db, 2)
-
-	// set up test helpers
-	// basically, we hook into the run process to know when all workers have run.
-	// once we know that number, we set up a test to verify that we reach that number
-	numWorkers := len(knownWorkersList)
-	calledCh := make(chan bool, numWorkers*2) // making extra room, in case there are extras (which would be a failure)
-	mockHandler := buildRequestMock(
-		func(w *httptest.ResponseRecorder) {
-			calledCh <- true
+		testSuccess := buildRequestMock(func(w *httptest.ResponseRecorder) {
+			wasCalled = true
 			w.WriteHeader(http.StatusOK)
 			w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "ok"}))
 		})
 
-	for _, v := range knownWorkersList {
-		enhancementservices.SetWebRequestFunctionForWorker(v.Name, &mockHandler)
-	}
+		testFailure := buildRequestMock(func(w *httptest.ResponseRecorder) {
+			wasCalled = true
+			w.WriteHeader(http.StatusOK)
+			w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "error", Message: helpers.Ptr("oops")}))
+		})
 
-	tryRun := func(u models.User, input services.RunServiceWorkerInput) error {
-		ctx := contextForUser(u, db)
-		return services.RunServiceWorker(ctx, db, input)
-	}
-	allWorkersCalled := makeNotifierChannel()
+		tryTest := func(u models.User, id int64) (*dtos.ServiceWorkerTestOutput, error) {
+			ctx := contextForUser(u, db)
+			return services.TestServiceWorker(ctx, db, id)
+		}
 
-	evi := EviDobby
-	op := HarryPotterSeedData.OperationForEvidence(evi)
-	input := services.RunServiceWorkerInput{
-		OperationSlug: op.Slug,
-		EvidenceUUID:  evi.UUID,
-		WorkerName:    singleWorker.Name,
-	}
+		// verify permissions
+		_, err := tryTest(UserRon, worker.ID)
+		require.Error(t, err) // non-admin
 
-	// verify permissions
-	require.Error(t, tryRun(UserDraco, input)) // no access
+		// verify result (success)
+		enhancementservices.SetWebRequestFunctionForWorker(worker.Name, &testSuccess)
+		out, err := tryTest(UserDumbledore, worker.ID)
+		require.NoError(t, err)
+		require.True(t, wasCalled)
+		require.Equal(t, worker.ID, out.ID)
+		require.Equal(t, worker.Name, out.Name)
+		require.True(t, out.Live)
 
-	// verify result (single worker)
-	require.NoError(t, tryRun(UserRon, input))
-	<-allWorkersCalled // wait for the work to complete
-	require.Equal(t, 1, len(calledCh))
-	<-calledCh // empty the channel
+		// verify result (failure)
+		wasCalled = false // reset to un-called
+		enhancementservices.SetWebRequestFunctionForWorker(worker.Name, &testFailure)
+		out, err = tryTest(UserDumbledore, worker.ID)
+		require.NoError(t, err)
+		require.True(t, wasCalled)
+		require.Equal(t, worker.ID, out.ID)
+		require.Equal(t, worker.Name, out.Name)
+		require.False(t, out.Live)
+	})
+}
 
-	// verify result (all workers)
-	input.WorkerName = "" // set the trigger for executing all workers
-	require.NoError(t, tryRun(UserRon, input))
-	<-allWorkersCalled // wait for the work to complete
-	require.Equal(t, numWorkers, len(calledCh))
+func TestRunServiceWorker(t *testing.T) {
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		singleWorker := DemoServiceWorker
+
+		// pre-test: create another worker
+		makeAWorker(t, db, "IsAHorcrux")
+		knownWorkersList := requireNumberOfWorkers(t, db, 2)
+
+		// set up test helpers
+		// basically, we hook into the run process to know when all workers have run.
+		// once we know that number, we set up a test to verify that we reach that number
+		numWorkers := len(knownWorkersList)
+		calledCh := make(chan bool, numWorkers*2) // making extra room, in case there are extras (which would be a failure)
+		mockHandler := buildRequestMock(
+			func(w *httptest.ResponseRecorder) {
+				calledCh <- true
+				w.WriteHeader(http.StatusOK)
+				w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "ok"}))
+			})
+
+		for _, v := range knownWorkersList {
+			enhancementservices.SetWebRequestFunctionForWorker(v.Name, &mockHandler)
+		}
+
+		tryRun := func(u models.User, input services.RunServiceWorkerInput) error {
+			ctx := contextForUser(u, db)
+			return services.RunServiceWorker(ctx, db, input)
+		}
+		allWorkersCalled := makeNotifierChannel()
+
+		evi := EviDobby
+		op := seed.OperationForEvidence(evi)
+		input := services.RunServiceWorkerInput{
+			OperationSlug: op.Slug,
+			EvidenceUUID:  evi.UUID,
+			WorkerName:    singleWorker.Name,
+		}
+
+		// verify permissions
+		require.Error(t, tryRun(UserDraco, input)) // no access
+
+		// verify result (single worker)
+		require.NoError(t, tryRun(UserRon, input))
+		<-allWorkersCalled // wait for the work to complete
+		require.Equal(t, 1, len(calledCh))
+		<-calledCh // empty the channel
+
+		// verify result (all workers)
+		input.WorkerName = "" // set the trigger for executing all workers
+		require.NoError(t, tryRun(UserRon, input))
+		<-allWorkersCalled // wait for the work to complete
+		require.Equal(t, numWorkers, len(calledCh))
+	})
 }
 
 func TestBatchRunServiceWorker(t *testing.T) {
 	// This test is complicated. Basically, we need to hook into many systems and replace their
 	// default operation with a mock version. Once we do all of that, then we can verify that
 	// a worker was called.
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	singleWorker := DemoServiceWorker
 
-	// pre-test: create another worker
-	altWorker := makeAWorker(t, db, "IsAHorcrux")
-	knownWorkersList := []models.ServiceWorker{
-		singleWorker,
-		altWorker,
-	}
-	numWorkers := len(knownWorkersList)
+	RunResettableDBTest(t, func(db *database.Connection, seed TestSeedData) {
+		singleWorker := DemoServiceWorker
 
-	op := OpChamberOfSecrets
-	setOfEvidence := HarryPotterSeedData.EvidenceForOperation(op.ID)
-	expectedCalls := len(setOfEvidence) * numWorkers
-	calledCh := make(chan bool, expectedCalls*2) // making extra room, in case there are extras (which would be a failure)
-	allWorkersCalled := makeNotifierChannel()
+		// pre-test: create another worker
+		altWorker := makeAWorker(t, db, "IsAHorcrux")
+		knownWorkersList := []models.ServiceWorker{
+			singleWorker,
+			altWorker,
+		}
+		numWorkers := len(knownWorkersList)
 
-	tryBatchRun := func(u models.User, input services.BatchRunServiceWorkerInput) error {
-		ctx := contextForUser(u, db)
-		return services.BatchRunServiceWorker(ctx, db, input)
-	}
-	mockHandler := buildRequestMock(
-		func(w *httptest.ResponseRecorder) {
-			calledCh <- true
-			w.WriteHeader(http.StatusOK)
-			// we actually don't really care about the data -- other tests establish that the data
-			// needs to match a specific shape to make sense and produce the correct result.
-			w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "ok"}))
-		})
-	for _, v := range knownWorkersList {
-		enhancementservices.SetWebRequestFunctionForWorker(v.Name, &mockHandler)
-	}
+		op := OpChamberOfSecrets
+		setOfEvidence := seed.EvidenceForOperation(op.ID)
+		expectedCalls := len(setOfEvidence) * numWorkers
+		calledCh := make(chan bool, expectedCalls*2) // making extra room, in case there are extras (which would be a failure)
+		allWorkersCalled := makeNotifierChannel()
 
-	input := services.BatchRunServiceWorkerInput{
-		OperationSlug: op.Slug,
-		EvidenceUUIDs: helpers.Map(setOfEvidence, func(e models.Evidence) string { return e.UUID }),
-		WorkerNames:   helpers.Map(knownWorkersList, func(w models.ServiceWorker) string { return w.Name }),
-	}
+		tryBatchRun := func(u models.User, input services.BatchRunServiceWorkerInput) error {
+			ctx := contextForUser(u, db)
+			return services.BatchRunServiceWorker(ctx, db, input)
+		}
+		mockHandler := buildRequestMock(
+			func(w *httptest.ResponseRecorder) {
+				calledCh <- true
+				w.WriteHeader(http.StatusOK)
+				// we actually don't really care about the data -- other tests establish that the data
+				// needs to match a specific shape to make sense and produce the correct result.
+				w.Write(mustJSONMarshal(t, enhancementservices.TestResp{Status: "ok"}))
+			})
+		for _, v := range knownWorkersList {
+			enhancementservices.SetWebRequestFunctionForWorker(v.Name, &mockHandler)
+		}
 
-	// verify permissions
-	require.Error(t, tryBatchRun(UserDraco, input)) // no access
+		input := services.BatchRunServiceWorkerInput{
+			OperationSlug: op.Slug,
+			EvidenceUUIDs: helpers.Map(setOfEvidence, func(e models.Evidence) string { return e.UUID }),
+			WorkerNames:   helpers.Map(knownWorkersList, func(w models.ServiceWorker) string { return w.Name }),
+		}
 
-	// verify result
-	require.NoError(t, tryBatchRun(UserRon, input))
-	<-allWorkersCalled // wait for the work to complete
-	require.Equal(t, expectedCalls, len(calledCh))
+		// verify permissions
+		require.Error(t, tryBatchRun(UserDraco, input)) // no access
+
+		// verify result
+		require.NoError(t, tryBatchRun(UserRon, input))
+		<-allWorkersCalled // wait for the work to complete
+		require.Equal(t, expectedCalls, len(calledCh))
+	})
 }
 
 func buildRequestMock(writeResponse func(*httptest.ResponseRecorder)) enhancementservices.RequestFn {

--- a/backend/services/test_helpers_test.go
+++ b/backend/services/test_helpers_test.go
@@ -1,0 +1,51 @@
+package services_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/theparanoids/ashirt-server/backend/database"
+	"github.com/theparanoids/ashirt-server/backend/database/seeding"
+)
+
+var retrieveMutex sync.Mutex
+var servicesDB *database.Connection
+
+func GetReusableTestDatabase(t *testing.T) *database.Connection {
+	retrieveMutex.Lock()
+	if servicesDB == nil {
+		servicesDB = initTest(t)
+	}
+	retrieveMutex.Unlock()
+	return servicesDB
+}
+
+// RunResettableDBTest creates a database connection, seeds the database with the standard seed, then
+// runs the test. This can be used for all tests to provide a consistant test environment. Note that
+// this uses RunReusableDBTestWithSeed under-the-hood, and so is not appropriate for tests that require
+// a fresh database.
+func RunResettableDBTest(t *testing.T, fn func(*database.Connection, TestSeedData)) {
+	RunReusableDBTestWithSeed(t, HarryPotterSeedData, fn)
+}
+
+// RunReusableDBTestWithSeed re-uses the already-established database connection. The seed data is reset,
+// but any auto-incremented values within the database will remain as-is. This may be important for
+// specific tests. See RunDisposableDBTestWithSeed if you think you might need a completely fresh
+// database instance.
+func RunReusableDBTestWithSeed(t *testing.T, seed TestSeedData, fn func(*database.Connection, TestSeedData)) {
+	db := GetReusableTestDatabase(t)
+	seed.ApplyTo(t, db)
+	fn(db, seed)
+	seeding.ClearDB(db)
+}
+
+// RunDisposableDBTestWithSeed creates a connection to a database server, creates a fresh database instance,
+// and returns that instance with some seed data applied. This differs from RunReusableDBTestWithSeed
+// by the destroy-create process. At the end of this process, the network connection is closed, and
+// future usages will have a fresh instance.
+func RunDisposableDBTestWithSeed(t *testing.T, seed TestSeedData, fn func(*database.Connection, TestSeedData)) {
+	db := initTest(t)
+	defer db.DB.Close()
+	seed.ApplyTo(t, db)
+	fn(db, seed)
+}

--- a/backend/services/user_test.go
+++ b/backend/services/user_test.go
@@ -19,103 +19,101 @@ import (
 type userValidator func(*testing.T, UserOpPermJoinUser, *dtos.UserOperationRole)
 
 func TestCreateUser(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	// verify first user is an admin
-	i := services.CreateUserInput{
-		FirstName: "Luna",
-		LastName:  "Lovegood",
-		Slug:      "luna.lovegood",
-		Email:     "luna.lovegood@hogwarts.edu",
-	}
+	RunDisposableDBTestWithSeed(t, NoSeedData, func(db *database.Connection, _ TestSeedData) {
+		// verify first user is an admin
+		i := services.CreateUserInput{
+			FirstName: "Luna",
+			LastName:  "Lovegood",
+			Slug:      "luna.lovegood",
+			Email:     "luna.lovegood@hogwarts.edu",
+		}
 
-	createUserOutput, err := services.CreateUser(db, i)
-	require.NoError(t, err)
-	require.Equal(t, createUserOutput.RealSlug, i.Slug)
-	luna := getUserProfile(t, db, createUserOutput.UserID)
+		createUserOutput, err := services.CreateUser(db, i)
+		require.NoError(t, err)
+		require.Equal(t, createUserOutput.RealSlug, i.Slug)
+		luna := getUserProfile(t, db, createUserOutput.UserID)
 
-	require.Equal(t, true, luna.Admin)
-	require.Equal(t, luna.FirstName, i.FirstName)
-	require.Equal(t, luna.Email, i.Email)
-	require.Equal(t, luna.LastName, i.LastName)
+		require.Equal(t, true, luna.Admin)
+		require.Equal(t, luna.FirstName, i.FirstName)
+		require.Equal(t, luna.Email, i.Email)
+		require.Equal(t, luna.LastName, i.LastName)
 
-	// Verify re-register will fail (due to unique email constraint)
-	_, err = services.CreateUser(db, i)
-	require.Error(t, err)
+		// Verify re-register will fail (due to unique email constraint)
+		_, err = services.CreateUser(db, i)
+		require.Error(t, err)
 
-	// Verify 2nd user (non-admin, no matching slug)
-	i.Email = "luna.lovegood+extra@hogwarts.edu" // change the password to something that won't exist
-	createUserOutput, err = services.CreateUser(db, i)
-	require.NoError(t, err)
-	// Since Luna's already exists, a new slug should be created
-	require.NotEqual(t, i.Slug, createUserOutput.RealSlug)
-	require.Contains(t, createUserOutput.RealSlug, i.Slug)
-	newLuna := getUserProfile(t, db, createUserOutput.UserID)
+		// Verify 2nd user (non-admin, no matching slug)
+		i.Email = "luna.lovegood+extra@hogwarts.edu" // change the password to something that won't exist
+		createUserOutput, err = services.CreateUser(db, i)
+		require.NoError(t, err)
+		// Since Luna's already exists, a new slug should be created
+		require.NotEqual(t, i.Slug, createUserOutput.RealSlug)
+		require.Contains(t, createUserOutput.RealSlug, i.Slug)
+		newLuna := getUserProfile(t, db, createUserOutput.UserID)
 
-	require.Equal(t, false, newLuna.Admin)
-	require.Equal(t, i.FirstName, newLuna.FirstName)
-	require.Equal(t, i.Email, newLuna.Email)
-	require.Equal(t, i.LastName, newLuna.LastName)
+		require.Equal(t, false, newLuna.Admin)
+		require.Equal(t, i.FirstName, newLuna.FirstName)
+		require.Equal(t, i.Email, newLuna.Email)
+		require.Equal(t, i.LastName, newLuna.LastName)
+	})
 }
 
 func TestCreateHeadlessUser(t *testing.T) {
-	db := initTest(t)
-	defer db.DB.Close()
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		i := services.CreateUserInput{
+			FirstName: "Extra",
+			LastName:  "Headless Hunt Member",
+			Slug:      "sir.nobody",
+			Email:     "sir.nobody@hogwarts.edu",
+		}
 
-	i := services.CreateUserInput{
-		FirstName: "Extra",
-		LastName:  "Headless Hunt Member",
-		Slug:      "sir.nobody",
-		Email:     "sir.nobody@hogwarts.edu",
-	}
+		// Verify non-admin can not create headless users
+		ctx := contextForUser(UserHarry, db)
+		_, err := services.CreateHeadlessUser(ctx, db, i)
+		require.Error(t, err)
 
-	// Verify non-admin can not create headless users
-	ctx := contextForUser(UserHarry, db)
-	_, err := services.CreateHeadlessUser(ctx, db, i)
-	require.Error(t, err)
+		ctx = contextForUser(UserDumbledore, db)
+		result, err := services.CreateHeadlessUser(ctx, db, i)
+		require.NoError(t, err)
 
-	ctx = contextForUser(UserDumbledore, db)
-	result, err := services.CreateHeadlessUser(ctx, db, i)
-	require.NoError(t, err)
+		foundUser := getUserBySlug(t, db, result.RealSlug)
 
-	foundUser := getUserBySlug(t, db, result.RealSlug)
-
-	require.True(t, foundUser.Headless)
+		require.True(t, foundUser.Headless)
+	})
 }
 
 func TestDeleteUser(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	targetUser := UserRon
-	admin := UserDumbledore
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		targetUser := UserRon
+		admin := UserDumbledore
 
-	require.True(t, 0 < countRows(t, db, "api_keys", "user_id=?", targetUser.ID))
-	require.True(t, 0 < countRows(t, db, "auth_scheme_data", "user_id=?", targetUser.ID))
-	require.True(t, 0 < countRows(t, db, "user_operation_permissions", "user_id=?", targetUser.ID))
+		require.True(t, 0 < countRows(t, db, "api_keys", "user_id=?", targetUser.ID))
+		require.True(t, 0 < countRows(t, db, "auth_scheme_data", "user_id=?", targetUser.ID))
+		require.True(t, 0 < countRows(t, db, "user_operation_permissions", "user_id=?", targetUser.ID))
 
-	// verify that non-admins cannot delete
-	ctx := contextForUser(UserDraco, db)
-	err := services.DeleteUser(ctx, db, targetUser.Slug)
-	require.Error(t, err)
+		// verify that non-admins cannot delete
+		ctx := contextForUser(UserDraco, db)
+		err := services.DeleteUser(ctx, db, targetUser.Slug)
+		require.Error(t, err)
 
-	// verify user cannot delete themselves
-	ctx = contextForUser(admin, db)
-	err = services.DeleteUser(ctx, db, admin.Slug)
-	require.NotNil(t, err)
+		// verify user cannot delete themselves
+		ctx = contextForUser(admin, db)
+		err = services.DeleteUser(ctx, db, admin.Slug)
+		require.NotNil(t, err)
 
-	// Verify delete actually works
-	err = services.DeleteUser(ctx, db, targetUser.Slug)
-	require.Nil(t, err)
+		// Verify delete actually works
+		err = services.DeleteUser(ctx, db, targetUser.Slug)
+		require.Nil(t, err)
 
-	require.True(t, countRows(t, db, "api_keys", "user_id=?", targetUser.ID) == 0)
-	require.True(t, countRows(t, db, "auth_scheme_data", "user_id=?", targetUser.ID) == 0)
-	require.True(t, countRows(t, db, "user_operation_permissions", "user_id=?", targetUser.ID) == 0)
+		require.True(t, countRows(t, db, "api_keys", "user_id=?", targetUser.ID) == 0)
+		require.True(t, countRows(t, db, "auth_scheme_data", "user_id=?", targetUser.ID) == 0)
+		require.True(t, countRows(t, db, "user_operation_permissions", "user_id=?", targetUser.ID) == 0)
 
-	var user models.User
-	err = db.Get(&user, sq.Select("*").From("users").Where(sq.Eq{"id": targetUser.ID}))
-	require.Nil(t, err)
-	require.NotNil(t, user.DeletedAt)
+		var user models.User
+		err = db.Get(&user, sq.Select("*").From("users").Where(sq.Eq{"id": targetUser.ID}))
+		require.Nil(t, err)
+		require.NotNil(t, user.DeletedAt)
+	})
 }
 
 func TestListEvidenceCreatorsForOperation(t *testing.T) {
@@ -123,106 +121,105 @@ func TestListEvidenceCreatorsForOperation(t *testing.T) {
 }
 
 func TestListUsersForAdmin(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	allUsers := getAllUsers(t, db)
-	allDeletedUsers := getAllDeletedUsers(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		allUsers := getAllUsers(t, db)
+		allDeletedUsers := getAllDeletedUsers(t, db)
 
-	input := services.ListUsersForAdminInput{
-		Pagination: services.Pagination{
-			Page:     1,
-			PageSize: 250,
-		},
-		IncludeDeleted: false,
-	}
-	input.Pagination.SetMaxItems(input.Pagination.PageSize) // force constrain not to affect us
-
-	// verify access restricted for non-admins
-	ctx := contextForUser(UserDraco, db)
-	_, err := services.ListUsersForAdmin(ctx, db, input)
-	require.Error(t, err)
-
-	// Verify admins can list users (no deleted users)
-	ctx = contextForUser(UserDumbledore, db)
-	pagedUsers, err := services.ListUsersForAdmin(ctx, db, input)
-	require.NoError(t, err)
-
-	require.Equal(t, input.Pagination.PageSize, pagedUsers.PageSize)
-	require.Equal(t, int64(len(allUsers)-len(allDeletedUsers)), pagedUsers.TotalCount)
-
-	usersDto, ok := pagedUsers.Content.([]*dtos.UserAdminView)
-	require.True(t, ok)
-	dtoIndex := 0
-	for i := 0; i < len(allUsers); i++ {
-		if allUsers[i].DeletedAt != nil {
-			continue
+		input := services.ListUsersForAdminInput{
+			Pagination: services.Pagination{
+				Page:     1,
+				PageSize: 250,
+			},
+			IncludeDeleted: false,
 		}
-		require.Equal(t, allUsers[i].Slug, usersDto[dtoIndex].Slug)
-		require.Equal(t, allUsers[i].FirstName, usersDto[dtoIndex].FirstName)
-		require.Equal(t, allUsers[i].LastName, usersDto[dtoIndex].LastName)
-		require.Equal(t, allUsers[i].Admin, usersDto[dtoIndex].Admin)
-		require.Equal(t, allUsers[i].Disabled, usersDto[dtoIndex].Disabled)
-		require.Equal(t, allUsers[i].Email, usersDto[dtoIndex].Email)
-		require.Equal(t, allUsers[i].Headless, usersDto[dtoIndex].Headless)
-		require.Equal(t, false, usersDto[dtoIndex].Deleted)
-		dtoIndex++
-	}
+		input.Pagination.SetMaxItems(input.Pagination.PageSize) // force constrain not to affect us
 
-	// verify deleted users can be shown
-	input.IncludeDeleted = true
-	pagedUsers, err = services.ListUsersForAdmin(ctx, db, input)
-	require.Nil(t, err)
+		// verify access restricted for non-admins
+		ctx := contextForUser(UserDraco, db)
+		_, err := services.ListUsersForAdmin(ctx, db, input)
+		require.Error(t, err)
 
-	usersDto, _ = pagedUsers.Content.([]*dtos.UserAdminView)
-	for i := 0; i < len(allUsers); i++ {
-		require.Equal(t, allUsers[i].Slug, usersDto[i].Slug)
-		require.Equal(t, allUsers[i].FirstName, usersDto[i].FirstName)
-		require.Equal(t, allUsers[i].LastName, usersDto[i].LastName)
-		require.Equal(t, allUsers[i].Admin, usersDto[i].Admin)
-		require.Equal(t, allUsers[i].Disabled, usersDto[i].Disabled)
-		require.Equal(t, allUsers[i].Email, usersDto[i].Email)
-		require.Equal(t, allUsers[i].Headless, usersDto[i].Headless)
-		require.Equal(t, (allUsers[i].DeletedAt != nil), usersDto[i].Deleted)
-	}
+		// Verify admins can list users (no deleted users)
+		ctx = contextForUser(UserDumbledore, db)
+		pagedUsers, err := services.ListUsersForAdmin(ctx, db, input)
+		require.NoError(t, err)
+
+		require.Equal(t, input.Pagination.PageSize, pagedUsers.PageSize)
+		require.Equal(t, int64(len(allUsers)-len(allDeletedUsers)), pagedUsers.TotalCount)
+
+		usersDto, ok := pagedUsers.Content.([]*dtos.UserAdminView)
+		require.True(t, ok)
+		dtoIndex := 0
+		for i := 0; i < len(allUsers); i++ {
+			if allUsers[i].DeletedAt != nil {
+				continue
+			}
+			require.Equal(t, allUsers[i].Slug, usersDto[dtoIndex].Slug)
+			require.Equal(t, allUsers[i].FirstName, usersDto[dtoIndex].FirstName)
+			require.Equal(t, allUsers[i].LastName, usersDto[dtoIndex].LastName)
+			require.Equal(t, allUsers[i].Admin, usersDto[dtoIndex].Admin)
+			require.Equal(t, allUsers[i].Disabled, usersDto[dtoIndex].Disabled)
+			require.Equal(t, allUsers[i].Email, usersDto[dtoIndex].Email)
+			require.Equal(t, allUsers[i].Headless, usersDto[dtoIndex].Headless)
+			require.Equal(t, false, usersDto[dtoIndex].Deleted)
+			dtoIndex++
+		}
+
+		// verify deleted users can be shown
+		input.IncludeDeleted = true
+		pagedUsers, err = services.ListUsersForAdmin(ctx, db, input)
+		require.Nil(t, err)
+
+		usersDto, _ = pagedUsers.Content.([]*dtos.UserAdminView)
+		for i := 0; i < len(allUsers); i++ {
+			require.Equal(t, allUsers[i].Slug, usersDto[i].Slug)
+			require.Equal(t, allUsers[i].FirstName, usersDto[i].FirstName)
+			require.Equal(t, allUsers[i].LastName, usersDto[i].LastName)
+			require.Equal(t, allUsers[i].Admin, usersDto[i].Admin)
+			require.Equal(t, allUsers[i].Disabled, usersDto[i].Disabled)
+			require.Equal(t, allUsers[i].Email, usersDto[i].Email)
+			require.Equal(t, allUsers[i].Headless, usersDto[i].Headless)
+			require.Equal(t, (allUsers[i].DeletedAt != nil), usersDto[i].Deleted)
+		}
+	})
 }
 
 func TestListUsersForOperation(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	ctx := contextForUser(UserRon, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		ctx := contextForUser(UserRon, db)
 
-	masterOp := OpChamberOfSecrets
-	allUserOpRoles := getUsersWithRoleForOperationByOperationID(t, db, masterOp.ID)
-	require.NotEqual(t, len(allUserOpRoles), 0, "Some users should be attached to this operation")
+		masterOp := OpChamberOfSecrets
+		allUserOpRoles := getUsersWithRoleForOperationByOperationID(t, db, masterOp.ID)
+		require.NotEqual(t, len(allUserOpRoles), 0, "Some users should be attached to this operation")
 
-	input := services.ListUsersForOperationInput{
-		OperationSlug: masterOp.Slug,
-	}
+		input := services.ListUsersForOperationInput{
+			OperationSlug: masterOp.Slug,
+		}
 
-	content, err := services.ListUsersForOperation(ctx, db, input)
-	require.NoError(t, err)
+		content, err := services.ListUsersForOperation(ctx, db, input)
+		require.NoError(t, err)
 
-	require.Equal(t, len(content), len(allUserOpRoles))
-	validateUserSets(t, content, allUserOpRoles, validateUser)
+		require.Equal(t, len(content), len(allUserOpRoles))
+		validateUserSets(t, content, allUserOpRoles, validateUser)
+	})
 }
 
 func TestListUsers(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		testListUsersCase(t, db, "harry potter", true, []models.User{UserHarry})
+		testListUsersCase(t, db, "granger", true, []models.User{UserHermione})
+		testListUsersCase(t, db, "al", true, []models.User{UserAlastor, UserDumbledore, UserDraco, UserLucius, UserMinerva})
+		testListUsersCase(t, db, "dra mal", true, []models.User{UserDraco})
+		testListUsersCase(t, db, "", true, []models.User{})
+		testListUsersCase(t, db, "  ", true, []models.User{})
+		testListUsersCase(t, db, "%", true, []models.User{})
+		testListUsersCase(t, db, "*", true, []models.User{})
+		testListUsersCase(t, db, "___", true, []models.User{})
 
-	testListUsersCase(t, db, "harry potter", true, []models.User{UserHarry})
-	testListUsersCase(t, db, "granger", true, []models.User{UserHermione})
-	testListUsersCase(t, db, "al", true, []models.User{UserAlastor, UserDumbledore, UserDraco, UserLucius, UserMinerva})
-	testListUsersCase(t, db, "dra mal", true, []models.User{UserDraco})
-	testListUsersCase(t, db, "", true, []models.User{})
-	testListUsersCase(t, db, "  ", true, []models.User{})
-	testListUsersCase(t, db, "%", true, []models.User{})
-	testListUsersCase(t, db, "*", true, []models.User{})
-	testListUsersCase(t, db, "___", true, []models.User{})
-
-	// test for deleted user filtering
-	testListUsersCase(t, db, UserTomRiddle.LastName, true, []models.User{UserTomRiddle})
-	testListUsersCase(t, db, UserTomRiddle.LastName, false, []models.User{})
+		// test for deleted user filtering
+		testListUsersCase(t, db, UserTomRiddle.LastName, true, []models.User{UserTomRiddle})
+		testListUsersCase(t, db, UserTomRiddle.LastName, false, []models.User{})
+	})
 }
 
 func testListUsersCase(t *testing.T, db *database.Connection, query string, includeDeleted bool, expectedUsers []models.User) {
@@ -264,45 +261,45 @@ func validateUserSets(t *testing.T, dtoSet []*dtos.UserOperationRole, dbSet []Us
 }
 
 func TestReadUser(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	normalUser := UserRon
-	targetUser := UserHarry
-	adminUser := UserDumbledore
-	ctx := contextForUser(normalUser, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		targetUser := UserHarry
+		adminUser := UserDumbledore
+		ctx := contextForUser(normalUser, db)
 
-	supportedAuthSchemes := []dtos.SupportedAuthScheme{
-		{SchemeName: "Local", SchemeCode: "local"},
-	}
+		supportedAuthSchemes := []dtos.SupportedAuthScheme{
+			{SchemeName: "Local", SchemeCode: "local"},
+		}
 
-	// verify read-self
-	retrievedUser, err := services.ReadUser(ctx, db, "", &supportedAuthSchemes)
-	require.NoError(t, err)
-	verifyRetrievedUser(t, normalUser, retrievedUser, supportedAuthSchemes)
+		// verify read-self
+		retrievedUser, err := services.ReadUser(ctx, db, "", &supportedAuthSchemes)
+		require.NoError(t, err)
+		verifyRetrievedUser(t, normalUser, retrievedUser, supportedAuthSchemes)
 
-	// verify read-self alternative (userslug provided)
-	retrievedUser, err = services.ReadUser(ctx, db, normalUser.Slug, &supportedAuthSchemes)
-	require.NoError(t, err)
-	verifyRetrievedUser(t, normalUser, retrievedUser, supportedAuthSchemes)
+		// verify read-self alternative (userslug provided)
+		retrievedUser, err = services.ReadUser(ctx, db, normalUser.Slug, &supportedAuthSchemes)
+		require.NoError(t, err)
+		verifyRetrievedUser(t, normalUser, retrievedUser, supportedAuthSchemes)
 
-	// verify read-other (non-admin : should fail)
-	_, err = services.ReadUser(ctx, db, targetUser.Slug, &supportedAuthSchemes)
-	require.Error(t, err)
+		// verify read-other (non-admin : should fail)
+		_, err = services.ReadUser(ctx, db, targetUser.Slug, &supportedAuthSchemes)
+		require.Error(t, err)
 
-	// verify read-other (as admin)
-	ctx = contextForUser(adminUser, db)
-	retrievedUser, err = services.ReadUser(ctx, db, targetUser.Slug, &supportedAuthSchemes)
-	require.NoError(t, err)
-	verifyRetrievedUser(t, targetUser, retrievedUser, supportedAuthSchemes)
+		// verify read-other (as admin)
+		ctx = contextForUser(adminUser, db)
+		retrievedUser, err = services.ReadUser(ctx, db, targetUser.Slug, &supportedAuthSchemes)
+		require.NoError(t, err)
+		verifyRetrievedUser(t, targetUser, retrievedUser, supportedAuthSchemes)
 
-	// verify old/removed auth schemes are filtered out
-	ctx = contextForUser(normalUser, db)
-	supportedAuthSchemes = []dtos.SupportedAuthScheme{
-		{SchemeName: "Petronus", SchemeCode: "petroni"},
-	}
-	retrievedUser, err = services.ReadUser(ctx, db, "", &supportedAuthSchemes)
-	require.NoError(t, err)
-	verifyRetrievedUser(t, normalUser, retrievedUser, []dtos.SupportedAuthScheme{})
+		// verify old/removed auth schemes are filtered out
+		ctx = contextForUser(normalUser, db)
+		supportedAuthSchemes = []dtos.SupportedAuthScheme{
+			{SchemeName: "Petronus", SchemeCode: "petroni"},
+		}
+		retrievedUser, err = services.ReadUser(ctx, db, "", &supportedAuthSchemes)
+		require.NoError(t, err)
+		verifyRetrievedUser(t, normalUser, retrievedUser, []dtos.SupportedAuthScheme{})
+	})
 }
 
 func verifyRetrievedUser(t *testing.T, expectedUser models.User, retrievedUser *dtos.UserOwnView, expectedAuths []dtos.SupportedAuthScheme) {
@@ -324,45 +321,44 @@ func verifyRetrievedUser(t *testing.T, expectedUser models.User, retrievedUser *
 }
 
 func TestUpdateUserProfile(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	normalUser := UserRon
-	targetUser := UserHarry
-	adminUser := UserDumbledore
-	ctx := contextForUser(normalUser, db)
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		normalUser := UserRon
+		targetUser := UserHarry
+		adminUser := UserDumbledore
+		ctx := contextForUser(normalUser, db)
 
-	// verify read-self
-	verifyUserProfileUpdate(t, false, ctx, db, normalUser.ID, services.UpdateUserProfileInput{
-		FirstName: "Stan",
-		LastName:  "Shunpike",
-		Email:     "sshunpike@hogwarts.edu",
+		// verify read-self
+		verifyUserProfileUpdate(t, false, ctx, db, normalUser.ID, services.UpdateUserProfileInput{
+			FirstName: "Stan",
+			LastName:  "Shunpike",
+			Email:     "sshunpike@hogwarts.edu",
+		})
+
+		// verify read-self (alternate)
+		verifyUserProfileUpdate(t, false, ctx, db, normalUser.ID, services.UpdateUserProfileInput{
+			UserSlug:  normalUser.Slug,
+			FirstName: "Stan2",
+			LastName:  "Shunpike2",
+			Email:     "sshunpike2@hogwarts.edu",
+		})
+
+		// verify read-other (non-admin)
+		verifyUserProfileUpdate(t, true, ctx, db, targetUser.ID, services.UpdateUserProfileInput{
+			UserSlug:  targetUser.Slug,
+			FirstName: "Stan3",
+			LastName:  "Shunpike3",
+			Email:     "sshunpike3@hogwarts.edu",
+		})
+
+		// verify read-other (admin)
+		ctx = contextForUser(adminUser, db)
+		verifyUserProfileUpdate(t, false, ctx, db, targetUser.ID, services.UpdateUserProfileInput{
+			UserSlug:  targetUser.Slug,
+			FirstName: "Stan4",
+			LastName:  "Shunpike4",
+			Email:     "sshunpike4@hogwarts.edu",
+		})
 	})
-
-	// verify read-self (alternate)
-	verifyUserProfileUpdate(t, false, ctx, db, normalUser.ID, services.UpdateUserProfileInput{
-		UserSlug:  normalUser.Slug,
-		FirstName: "Stan2",
-		LastName:  "Shunpike2",
-		Email:     "sshunpike2@hogwarts.edu",
-	})
-
-	// verify read-other (non-admin)
-	verifyUserProfileUpdate(t, true, ctx, db, targetUser.ID, services.UpdateUserProfileInput{
-		UserSlug:  targetUser.Slug,
-		FirstName: "Stan3",
-		LastName:  "Shunpike3",
-		Email:     "sshunpike3@hogwarts.edu",
-	})
-
-	// verify read-other (admin)
-	ctx = contextForUser(adminUser, db)
-	verifyUserProfileUpdate(t, false, ctx, db, targetUser.ID, services.UpdateUserProfileInput{
-		UserSlug:  targetUser.Slug,
-		FirstName: "Stan4",
-		LastName:  "Shunpike4",
-		Email:     "sshunpike4@hogwarts.edu",
-	})
-
 }
 
 func verifyUserProfileUpdate(t *testing.T, expectError bool, ctx context.Context, db *database.Connection, userID int64, updatedData services.UpdateUserProfileInput) {
@@ -382,109 +378,109 @@ func verifyUserProfileUpdate(t *testing.T, expectError bool, ctx context.Context
 }
 
 func TestDeleteSessionsForUserSlug(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	targetedUser := UserDraco
-	alsoPresentUser := UserHarry
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		targetedUser := UserDraco
+		alsoPresentUser := UserHarry
 
-	// populate some sessions
-	sessionsToAdd := []models.Session{
-		{UserID: targetedUser.ID, SessionData: []byte("a")},
-		{UserID: alsoPresentUser.ID, SessionData: []byte("b")},
-		{UserID: targetedUser.ID, SessionData: []byte("c")},
-		{UserID: alsoPresentUser.ID, SessionData: []byte("d")},
-	}
-	err := db.BatchInsert("sessions", len(sessionsToAdd), func(i int) map[string]interface{} {
-		return map[string]interface{}{
-			"user_id":      sessionsToAdd[i].UserID,
-			"session_data": sessionsToAdd[i].SessionData,
+		// populate some sessions
+		sessionsToAdd := []models.Session{
+			{UserID: targetedUser.ID, SessionData: []byte("a")},
+			{UserID: alsoPresentUser.ID, SessionData: []byte("b")},
+			{UserID: targetedUser.ID, SessionData: []byte("c")},
+			{UserID: alsoPresentUser.ID, SessionData: []byte("d")},
 		}
+		err := db.BatchInsert("sessions", len(sessionsToAdd), func(i int) map[string]interface{} {
+			return map[string]interface{}{
+				"user_id":      sessionsToAdd[i].UserID,
+				"session_data": sessionsToAdd[i].SessionData,
+			}
+		})
+
+		require.NoError(t, err)
+
+		// verify sessions exist
+		var targetedUserSessions []models.Session
+		err = db.Select(&targetedUserSessions, sq.Select("*").From("sessions").Where(sq.Eq{"user_id": targetedUser.ID}))
+		require.NoError(t, err)
+		require.True(t, len(targetedUserSessions) > 0)
+
+		// verify non-admin cannot delete session data
+		ctx := contextForUser(UserHarry, db)
+		err = services.DeleteSessionsForUserSlug(ctx, db, targetedUser.Slug)
+		require.Error(t, err)
+
+		// verify admin can delete session data
+		ctx = contextForUser(UserDumbledore, db)
+		err = services.DeleteSessionsForUserSlug(ctx, db, targetedUser.Slug)
+		require.NoError(t, err)
+
+		targetedUserSessions = []models.Session{}
+		err = db.Select(&targetedUserSessions, sq.Select("*").From("sessions").Where(sq.Eq{"user_id": targetedUser.ID}))
+		require.NoError(t, err)
+		require.True(t, len(targetedUserSessions) == 0)
 	})
-
-	require.NoError(t, err)
-
-	// verify sessions exist
-	var targetedUserSessions []models.Session
-	err = db.Select(&targetedUserSessions, sq.Select("*").From("sessions").Where(sq.Eq{"user_id": targetedUser.ID}))
-	require.NoError(t, err)
-	require.True(t, len(targetedUserSessions) > 0)
-
-	// verify non-admin cannot delete session data
-	ctx := contextForUser(UserHarry, db)
-	err = services.DeleteSessionsForUserSlug(ctx, db, targetedUser.Slug)
-	require.Error(t, err)
-
-	// verify admin can delete session data
-	ctx = contextForUser(UserDumbledore, db)
-	err = services.DeleteSessionsForUserSlug(ctx, db, targetedUser.Slug)
-	require.NoError(t, err)
-
-	targetedUserSessions = []models.Session{}
-	err = db.Select(&targetedUserSessions, sq.Select("*").From("sessions").Where(sq.Eq{"user_id": targetedUser.ID}))
-	require.NoError(t, err)
-	require.True(t, len(targetedUserSessions) == 0)
 }
 
 func TestSetUserFlags(t *testing.T) {
-	db := initTest(t)
-	HarryPotterSeedData.ApplyTo(t, db)
-	targetUser := UserHarry
-	adminUser := UserDumbledore
-	admin := true
-	disabled := true
-	input := services.SetUserFlagsInput{
-		Slug:     targetUser.Slug,
-		Admin:    &admin,
-		Disabled: &disabled,
-	}
+	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
+		targetUser := UserHarry
+		adminUser := UserDumbledore
+		admin := true
+		disabled := true
+		input := services.SetUserFlagsInput{
+			Slug:     targetUser.Slug,
+			Admin:    &admin,
+			Disabled: &disabled,
+		}
 
-	// verify access restricted for non-admins
-	ctx := contextForUser(UserDraco, db)
-	err := services.SetUserFlags(ctx, db, input)
-	require.Error(t, err)
+		// verify access restricted for non-admins
+		ctx := contextForUser(UserDraco, db)
+		err := services.SetUserFlags(ctx, db, input)
+		require.Error(t, err)
 
-	// As an admin
-	ctx = contextForUser(adminUser, db)
+		// As an admin
+		ctx = contextForUser(adminUser, db)
 
-	// verify users can't disable themselves
-	sameUserInput := services.SetUserFlagsInput{
-		Slug:     adminUser.Slug,
-		Admin:    &admin,    // true at this point (no change)
-		Disabled: &disabled, // true at this point
-	}
-	err = services.SetUserFlags(ctx, db, sameUserInput)
-	require.Error(t, err)
+		// verify users can't disable themselves
+		sameUserInput := services.SetUserFlagsInput{
+			Slug:     adminUser.Slug,
+			Admin:    &admin,    // true at this point (no change)
+			Disabled: &disabled, // true at this point
+		}
+		err = services.SetUserFlags(ctx, db, sameUserInput)
+		require.Error(t, err)
 
-	// verify users can't demote themselves
-	disabled = false
-	admin = false
-	err = services.SetUserFlags(ctx, db, sameUserInput)
-	require.Error(t, err)
+		// verify users can't demote themselves
+		disabled = false
+		admin = false
+		err = services.SetUserFlags(ctx, db, sameUserInput)
+		require.Error(t, err)
 
-	// reset for next tests
-	disabled = true
-	admin = true
+		// reset for next tests
+		disabled = true
+		admin = true
 
-	// try setting and then unsetting admin/disabled
-	for i := 0; i < 2; i++ {
-		err = services.SetUserFlags(ctx, db, input)
-		require.NoError(t, err)
+		// try setting and then unsetting admin/disabled
+		for i := 0; i < 2; i++ {
+			err = services.SetUserFlags(ctx, db, input)
+			require.NoError(t, err)
 
-		dbProfile := getUserProfile(t, db, targetUser.ID)
+			dbProfile := getUserProfile(t, db, targetUser.ID)
 
-		require.Equal(t, admin, dbProfile.Admin)
-		require.Equal(t, disabled, dbProfile.Disabled)
+			require.Equal(t, admin, dbProfile.Admin)
+			require.Equal(t, disabled, dbProfile.Disabled)
 
-		// second test: Make sure setting to false also works
-		admin = !admin
-		disabled = !disabled
-	}
+			// second test: Make sure setting to false also works
+			admin = !admin
+			disabled = !disabled
+		}
 
-	// verify headless users cannot be admins
-	admin = true
-	err = services.SetUserFlags(ctx, db, services.SetUserFlagsInput{
-		Slug:  UserHeadlessNick.Slug,
-		Admin: &admin,
+		// verify headless users cannot be admins
+		admin = true
+		err = services.SetUserFlags(ctx, db, services.SetUserFlagsInput{
+			Slug:  UserHeadlessNick.Slug,
+			Admin: &admin,
+		})
+		require.Error(t, err)
 	})
-	require.Error(t, err)
 }


### PR DESCRIPTION
This PR creates some test helpers to properly clean up test resource and speed up tests for the services package in particular. The speed up is achieved by maintaining a single connection to the database and without re-creating the database on each test. Instead, tests will use the established connection and reset the database to a clean state, or if they need a truly clean state (as in the case with one test),, then there's another method that can be used to do what we did before.

Tests should be able 75% faster with this method, and we shouldn't run into issues where we utilize all database connections. There may be an even faster approach, but it requires a project-wide adjustment that is beyond the scope of this PR.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.