### PR TITLE
fix an issue where new ops could not view evidence

### DIFF
--- a/backend/services/user.go
+++ b/backend/services/user.go
@@ -228,7 +228,7 @@ func ListEvidenceCreatorsForOperation(ctx context.Context, db *database.Connecti
 		Distinct().
 		From("operations").
 		LeftJoin("evidence ON operations.id = evidence.operation_id").
-		LeftJoin("users ON evidence.operator_id = users.id").
+		InnerJoin("users ON evidence.operator_id = users.id").
 		Where(sq.Eq{"operations.slug": i.OperationSlug}).
 		OrderBy("users.first_name ASC")
 


### PR DESCRIPTION
This PR addresses a bug where when a user created an operation and viewed the operation, it was impossible to list the evidence for that operation until evidence was added (this was complicated by the fact that any error when rendering that page would have hidden the create evidence button). The core issue is that there are no users who have created evidence when we request a list of the users who created evidence for an operation. This would return a non-empty, but invalid list of users (equivalent to `[null]`), which essentially prevented parts of the page from rendering properly.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.