### PR TITLE
update services to be identical to template

### DIFF
--- a/enhancement_workers/demo-tesseract/src/services/helpers.ts
+++ b/enhancement_workers/demo-tesseract/src/services/helpers.ts
@@ -1,0 +1,49 @@
+import { randomFillSync } from "crypto"
+import { FileData } from "./types"
+
+function randomChars(length: number): string {
+  const buff = Buffer.alloc(length)
+  return randomFillSync(buff).toString('base64url')
+}
+
+export function encodeForm(fields: Record<string, string | undefined>, files: Record<string, FileData | undefined>) {
+  const boundary = "----AShirtFormData-" + randomChars(30)
+  const newline = "\r\n"
+  const boundaryStart = "--" + boundary + newline
+  const lastBoundary = "--" + boundary + "--" + newline
+
+  let fieldBuffer = Buffer.from("")
+  Object.entries(fields).forEach(([key, value]) => {
+    if (value === undefined) {
+      return
+    }
+    const text = boundaryStart +
+      `Content-Disposition: form-data; name="${key}"` +
+      newline + newline +
+      value +
+      newline
+    fieldBuffer = Buffer.concat([fieldBuffer, Buffer.from(text)])
+  })
+
+  let fileBuffer = Buffer.from("")
+  Object.entries(files).forEach(([key, fd]) => {
+    if (fd === undefined) {
+      return
+    }
+    const textPart = `${boundaryStart}` +
+      `Content-Disposition: form-data; name="${key}"; filename="${fd.filename}"` +
+      `${newline}Content-Type: ${fd.mimetype}` +
+      `${newline}${newline}`
+
+    fileBuffer = Buffer.concat([fileBuffer, Buffer.from(textPart), fd.content, Buffer.from(newline)])
+  })
+
+  return {
+    boundary: boundary,
+    data: Buffer.concat([
+      fieldBuffer,
+      fileBuffer,
+      Buffer.from(lastBoundary),
+    ])
+  }
+}

--- a/enhancement_workers/demo-tesseract/src/services/types.ts
+++ b/enhancement_workers/demo-tesseract/src/services/types.ts
@@ -1,0 +1,93 @@
+import { SupportedContentTypes } from 'src/helpers/request_validation'
+
+export type CheckConnectionOutput = {
+  ok: boolean
+}
+
+export type ReadEvidenceOutput = {
+  uuid: string
+  description: string
+  contentType: string
+  occurredAt: Date
+}
+
+export type EvidenceOutput = {
+  uuid: string
+  description: string
+  occurredAt: Date
+  operator: UserOutput
+  tags: Array<TagOutputItem>
+  contentType: string
+}
+
+export type ResponseWrapper<T> = {
+  responseCode: number,
+  contentType: string
+  data: T
+}
+
+export type CreateOperationInput = {
+  slug: string
+  name: string
+}
+
+export type OperationOutputItem = {
+  slug: string
+  name: string
+  numUsers: number // int
+  status: 1 | 2 | 3
+}
+
+export type UserOutput = {
+  firstName: string
+  lastName: string
+  slug: string
+}
+
+export type TagOutputItem = {
+  id: number // int
+  colorName: string
+  name: string
+}
+
+export type TagWithUsageOutputItem = TagOutputItem & {
+  evidenceCount: number // int
+}
+export type ListOperationTagsOutput = Array<TagWithUsageOutputItem>
+export type ListOperationsOutput = Array<OperationOutputItem>
+
+export type UpsertMetadataInput = {
+  source: string
+  body: string
+  status: string
+  message?: string
+  canProcess?: boolean
+}
+
+export type CreateEvidenceInput = {
+  notes: string
+  file: FileData
+  contentType?: typeof SupportedContentTypes[number]
+  occurred_at?: string
+  tagIds: Array<number> // int array
+}
+
+export type UpdateEvidenceInput = {
+  notes: string
+  file?: FileData
+  contentType?: typeof SupportedContentTypes[number]
+  occurred_at?: string
+  tagsToAdd?: Array<number> // int array
+  tagsToRemove?: Array<number> // int array
+}
+
+export type CreateTagInput = {
+  name: string
+  colorName: string
+}
+
+export type FileData = {
+  filename: string
+  mimetype: string
+  content: Buffer
+}


### PR DESCRIPTION
This PR updates the tesseract demo worker to use the set of services defined in the typescript-express library. This is done for a couple of reasons:

1. To resolve any discrepancies between versions (there were a couple, mostly due to uploading content)
2. The template had an overall nicer implementation, with better documentation
3. Provides a way for users to test out an established worker with an already-verified set of ashirt services

The downside to this is that we will add a bunch of dead code to this worker -- specifically, we won't ever call updateEvidence or createEvidence here. I think the pros outweigh the cons here, hence why this PR exists

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.