### PR TITLE
Bug Fix: actually handle lambda responses correctly

### DIFF
--- a/backend/enhancementservices/enhancement_helpers_test.go
+++ b/backend/enhancementservices/enhancement_helpers_test.go
@@ -113,8 +113,9 @@ func verifyProcessBody(t *testing.T, req *http.Request, expectedPayload this.New
 func wrapInAwsResponse(t *testing.T, data interface{}) []byte {
 	body, err := json.Marshal(data)
 	require.NoError(t, err)
-	resp := awsResponseContainer{
-		Body: string(body),
+	resp := this.LambdaResponse{
+		Body:       string(body),
+		StatusCode: 200,
 	}
 	respondWith, _ := json.Marshal(resp)
 	return respondWith

--- a/backend/enhancementservices/rie_interface.go
+++ b/backend/enhancementservices/rie_interface.go
@@ -60,6 +60,7 @@ func (l LambdaRIEClient) Invoke(input *lambda.InvokeInput) (*lambda.InvokeOutput
 	if len(respBody) == 0 {
 		return &out, nil
 	}
+	out.Payload = respBody
 
 	return &out, nil
 }

--- a/backend/enhancementservices/rie_interface.go
+++ b/backend/enhancementservices/rie_interface.go
@@ -5,7 +5,6 @@ package enhancementservices
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,21 +60,6 @@ func (l LambdaRIEClient) Invoke(input *lambda.InvokeInput) (*lambda.InvokeOutput
 	if len(respBody) == 0 {
 		return &out, nil
 	}
-
-	var data map[string]any
-	if err = json.Unmarshal(respBody, &data); err != nil {
-		return nil, err
-	}
-	body, ok := data["body"]
-	if !ok {
-		return nil, fmt.Errorf("unable to read lambda body")
-	}
-	strBody, ok := body.(string)
-	if !ok {
-		return nil, fmt.Errorf("lambda response body is not a string")
-	}
-
-	out.Payload = []byte(strBody)
 
 	return &out, nil
 }

--- a/backend/enhancementservices/types.go
+++ b/backend/enhancementservices/types.go
@@ -46,6 +46,11 @@ type TestResp struct {
 	Message *string `json:"message"`
 }
 
+type LambdaResponse struct {
+	StatusCode int    `json:"statusCode"`
+	Body       string `json:"body"`
+}
+
 func errorTestResult(err error) ServiceTestResult {
 	return ServiceTestResult{
 		Error: err,

--- a/backend/enhancementservices/worker_aws_test.go
+++ b/backend/enhancementservices/worker_aws_test.go
@@ -149,7 +149,3 @@ type awsProcessResp struct {
 	Action  string  `json:"action,omitempty"`  // Rejected | Deferred | Processed | Error
 	Content *string `json:"content,omitempty"` // Error => reason, Processed => Result
 }
-
-type awsResponseContainer struct {
-	Body string `json:"body"`
-}


### PR DESCRIPTION
This PR fixes an issue where the  RIE interface unwrapped lambda responses, instead of the actual worker. this made tests look positive, but broken when running actual lambda functions.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.