### PR TITLE
Revise login to use a username instead of an email address

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -361,7 +361,7 @@ Adding your own authentication is a 3 step process:
    1. This is the bulk of the work. There are two interface methods to implement:
       1. `Name`: Every authentication needs a distinct name. The specific name does not really matter, but should be distinct from other utilized authentication scheme names.
          1. Note: Although the name does not matter, custom authentications **must not** use `,` in their names, as this is important for querying in some cases.
-      2. `BindRoutes`: This provides a namespaced router that can be used to implement any routes needed to statisfy the authentication routine. In addition to the namespaced router a set of callback functions, called an AuthBridge, is provided to interact with the underlying system. Specifically, 3 functions have been provided to help provide access into the database: `CreateNewUser`, which attempts to instantiate a new _AShirt_ user into the database. `LoginUser`, which provides a mechanism for the backend to record a new session, and `FindUserAuthsByUserSlug`, which provides a mechanism to lookup existing users belonging to a specific identity provider (i.e. backing authscheme) and a user key (similar to a shortname or email, but specific to an authscheme).
+      2. `BindRoutes`: This provides a namespaced router that can be used to implement any routes needed to statisfy the authentication routine. In addition to the namespaced router a set of callback functions, called an AuthBridge, is provided to interact with the underlying system. Specifically, 3 functions have been provided to help provide access into the database: `CreateNewUser`, which attempts to instantiate a new _AShirt_ user into the database. `LoginUser`, which provides a mechanism for the backend to record a new session, and `FindUserAuthsByUserSlug`, which provides a mechanism to lookup existing users belonging to a specific identity provider (i.e. backing authscheme) and a username (similar to a shortname or email, but specific to an authscheme).
 2. The new authscheme needs to be "registered" so that the webserver will know to use it.
    1. Inside `bin/web.go`, create a new instance of the authscheme, then provide this as an argument to the `server.WebConfig` structure. Note that multiple authentication schemes can be present at once
 3. The frontend needs to be updated to provide a way to login via your new authentication scheme, which is outside the scope of this miniguide.
@@ -547,7 +547,7 @@ Unit tests should follow these guidelines:
 Note that this list may become out of date. Users with flags should be considered constant with respect to the below
 fields, and Harry, Ronald, Hermione, Seamus, Ginny and Neville should be considered constant for the below fields as well.
 
-| User                         | User key | Password   | Flags       | SS Permissions | CoS Permissions |
+| User                         | Username | Password   | Flags       | SS Permissions | CoS Permissions |
 | ---------------------------- | -------- | ---------- | ----------- | -------------- | --------------- |
 | Albus Dumbledore             | Albus    | `albus`    | Super Admin | Admin          | Admin           |
 | Harry Potter                 | Harry    | `harry`    |             | Admin          | Write           |

--- a/backend/authschemes/auth_bridge.go
+++ b/backend/authschemes/auth_bridge.go
@@ -396,6 +396,12 @@ func (ah AShirtAuthBridge) ValidateRegistrationInfo(email, username string) erro
 	return nil
 }
 
+// ValidateLinkingInfo checks if the user is linking with an unused username (for the auth scheme).
+// This is only intended for services that register locally and do not need to access another service.
+//
+// Note: this will leak info back to the user, to help indicate how to correct their
+// registration data. This should be less of an issue generally, as the user should have an
+// idea of who else is using ashirt
 func (ah AShirtAuthBridge) ValidateLinkingInfo(username string) error {
 	if taken, err := ah.IsUsernameTakenForAuth(username); err != nil {
 		return backend.DatabaseErr(err)

--- a/backend/authschemes/auth_bridge.go
+++ b/backend/authschemes/auth_bridge.go
@@ -186,6 +186,21 @@ func (ah AShirtAuthBridge) FindUserAuthByUserID(userID int64) (UserAuthData, err
 	return authData, nil
 }
 
+func (ah AShirtAuthBridge) FindAuthsForUsername(userKey string) (UserAuthData, error) {
+	var authData UserAuthData
+
+	err := ah.db.Get(&authData, sq.Select("user_id", "user_key", "encrypted_password", "must_reset_password", "totp_secret", "json_data").
+		From("auth_scheme_data").
+		Where(sq.Eq{
+			"user_key":    userKey,
+			"auth_scheme": ah.authSchemeName,
+		}))
+	if err != nil {
+		return UserAuthData{}, backend.DatabaseErr(err)
+	}
+	return authData, nil
+}
+
 func (ah AShirtAuthBridge) findUserAuthsByUserEmail(email string, includeDeleted bool) ([]UserAuthData, error) {
 	var authData []UserAuthData
 

--- a/backend/authschemes/auth_bridge.go
+++ b/backend/authschemes/auth_bridge.go
@@ -327,7 +327,7 @@ func (ah AShirtAuthBridge) OneTimeVerification(ctx context.Context, username str
 	var userID int64
 	err := ah.db.WithTx(ctx, func(tx *database.Transactable) {
 		tx.Get(&userID, sq.Select("user_id").From("auth_scheme_data").
-			Where(sq.Eq{"username": username}).                                                  // The recovery code exists...
+			Where(sq.Eq{"username": username}).                                                 // The recovery code exists...
 			Where("TIMESTAMPDIFF(minute, created_at, ?) < ?", time.Now(), expirationInMinutes)) // and the record hasn't expired
 
 		tx.Delete(sq.Delete("auth_scheme_data").Where(sq.Eq{"username": username}))

--- a/backend/authschemes/auth_bridge_test.go
+++ b/backend/authschemes/auth_bridge_test.go
@@ -116,8 +116,8 @@ func TestUserAuthCreationAndLookup(t *testing.T) {
 
 	userID := createDummyUser(t, bridge, "")
 	err := bridge.CreateNewAuthForUser(authschemes.UserAuthData{
-		UserID:  userID,
-		UserKey: "dummy-user-key",
+		UserID:   userID,
+		Username: "dummy-user-key",
 	})
 	require.NoError(t, err)
 
@@ -125,7 +125,7 @@ func TestUserAuthCreationAndLookup(t *testing.T) {
 		auth, err := bridge.FindUserAuth("dummy-user-key")
 		require.NoError(t, err)
 		require.Equal(t, userID, auth.UserID)
-		require.Equal(t, "dummy-user-key", auth.UserKey)
+		require.Equal(t, "dummy-user-key", auth.Username)
 	})
 
 	t.Run("Test FindUserAuthsByUserSlug", func(t *testing.T) {
@@ -133,12 +133,12 @@ func TestUserAuthCreationAndLookup(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, auths, 1)
 		require.Equal(t, userID, auths[0].UserID)
-		require.Equal(t, "dummy-user-key", auths[0].UserKey)
+		require.Equal(t, "dummy-user-key", auths[0].Username)
 	})
 
 	t.Run("Test UpdateAuthForUser", func(t *testing.T) {
 		authData := authschemes.UserAuthData{
-			UserKey:            "dummy-user-key",
+			Username:           "dummy-user-key",
 			EncryptedPassword:  []byte("encrypted-password"),
 			NeedsPasswordReset: true,
 		}
@@ -218,8 +218,8 @@ func TestFindUserAuthsByEmail(t *testing.T) {
 
 	userID := createDummyUser(t, bridge, "normal-user")
 	err := bridge.CreateNewAuthForUser(authschemes.UserAuthData{
-		UserID:  userID,
-		UserKey: "dummy-user-key",
+		UserID:   userID,
+		Username: "dummy-user-key",
 	})
 	require.NoError(t, err)
 

--- a/backend/authschemes/global_helpers.go
+++ b/backend/authschemes/global_helpers.go
@@ -17,7 +17,7 @@ func CreateNewAuthForUserGeneric(db *database.Connection, authSchemeName, authSc
 	_, err := db.Insert("auth_scheme_data", map[string]interface{}{
 		"auth_scheme":         authSchemeName,
 		"auth_type":           authSchemeType,
-		"username":            data.UserKey,
+		"username":            data.Username,
 		"user_id":             data.UserID,
 		"encrypted_password":  data.EncryptedPassword,
 		"totp_secret":         data.TOTPSecret,

--- a/backend/authschemes/global_helpers.go
+++ b/backend/authschemes/global_helpers.go
@@ -17,7 +17,7 @@ func CreateNewAuthForUserGeneric(db *database.Connection, authSchemeName, authSc
 	_, err := db.Insert("auth_scheme_data", map[string]interface{}{
 		"auth_scheme":         authSchemeName,
 		"auth_type":           authSchemeType,
-		"user_key":            data.UserKey,
+		"username":            data.UserKey,
 		"user_id":             data.UserID,
 		"encrypted_password":  data.EncryptedPassword,
 		"totp_secret":         data.TOTPSecret,

--- a/backend/authschemes/global_helpers_test.go
+++ b/backend/authschemes/global_helpers_test.go
@@ -15,8 +15,8 @@ func TestCreateNewAuthForUserGeneric(t *testing.T) {
 	userID := createDummyUser(t, bridge, "normalUser")
 
 	err := authschemes.CreateNewAuthForUserGeneric(db, "someauth", "someauth-type", authschemes.UserAuthData{
-		UserID:  userID,
-		UserKey: "dummy-user-key",
+		UserID:   userID,
+		Username: "dummy-user-key",
 	})
 
 	require.NoError(t, err)

--- a/backend/authschemes/localauth/services.go
+++ b/backend/authschemes/localauth/services.go
@@ -16,6 +16,7 @@ import (
 
 type RegistrationInfo struct {
 	Password           string
+	Username           string
 	Email              string
 	FirstName          string
 	LastName           string
@@ -79,7 +80,7 @@ func registerNewUser(ctx context.Context, bridge authschemes.AShirtAuthBridge, i
 	}
 	return bridge.CreateNewAuthForUser(authschemes.UserAuthData{
 		UserID:             userResult.UserID,
-		UserKey:            info.Email,
+		UserKey:            info.Username,
 		EncryptedPassword:  encryptedPassword,
 		NeedsPasswordReset: info.ForceResetPassword,
 	})

--- a/backend/authschemes/localauth/services.go
+++ b/backend/authschemes/localauth/services.go
@@ -80,7 +80,7 @@ func registerNewUser(ctx context.Context, bridge authschemes.AShirtAuthBridge, i
 	}
 	return bridge.CreateNewAuthForUser(authschemes.UserAuthData{
 		UserID:             userResult.UserID,
-		UserKey:            info.Username,
+		Username:           info.Username,
 		EncryptedPassword:  encryptedPassword,
 		NeedsPasswordReset: info.ForceResetPassword,
 	})

--- a/backend/authschemes/localauth/services_internal_test.go
+++ b/backend/authschemes/localauth/services_internal_test.go
@@ -59,7 +59,7 @@ func TestReadUserTotpStatus(t *testing.T) {
 	// give target user totp -- note: this will remove existing encrypted_password and must_reset_password values
 	err = bridge.UpdateAuthForUser(authschemes.UserAuthData{
 		TOTPSecret: helpers.Ptr("abc123"),
-		UserKey:    targetUser.FirstName,
+		Username:   targetUser.FirstName,
 	})
 	require.NoError(t, err)
 
@@ -89,7 +89,7 @@ func TestDeleteUserTotp(t *testing.T) {
 	// give target user TOTP
 	err = bridge.UpdateAuthForUser(authschemes.UserAuthData{
 		TOTPSecret: helpers.Ptr("abc123"),
-		UserKey:    targetUser.FirstName,
+		Username:   targetUser.FirstName,
 	})
 	require.NoError(t, err)
 
@@ -111,7 +111,7 @@ func TestDeleteUserTotp(t *testing.T) {
 	// re-give user totp
 	err = bridge.UpdateAuthForUser(authschemes.UserAuthData{
 		TOTPSecret: helpers.Ptr("abc123"),
-		UserKey:    targetUser.FirstName,
+		Username:   targetUser.FirstName,
 	})
 	require.NoError(t, err)
 

--- a/backend/authschemes/localauth/session.go
+++ b/backend/authschemes/localauth/session.go
@@ -1,3 +1,6 @@
+// Copyright 2022, Yahoo Inc.
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
 package localauth
 
 import (
@@ -10,11 +13,11 @@ import (
 // localAuthSession is saved as an authscheme session for users that have "some difficulty" in logging in --
 // i.e. a plain authentication is insufficient, and more action is required. Speciifically, this
 // comes in the following flavors:
-//  * User must reset their password
-//  * User must supply their TOTP code
+//   - User must reset their password
+//   - User must supply their TOTP code
 type localAuthSession struct {
 	SessionValid  bool
-	UserKey       string
+	Username      string
 	TOTPValidated bool
 }
 
@@ -33,7 +36,7 @@ func readLocalSession(r *http.Request, bridge authschemes.AShirtAuthBridge) *loc
 func (sess *localAuthSession) writeLocalSession(w http.ResponseWriter, r *http.Request, bridge authschemes.AShirtAuthBridge) error {
 	return bridge.SetAuthSchemeSession(w, r, &localAuthSession{
 		SessionValid:  true,
-		UserKey:       sess.UserKey,
+		Username:      sess.Username,
 		TOTPValidated: sess.TOTPValidated,
 	})
 }

--- a/backend/authschemes/oidcauth/oidc_auth.go
+++ b/backend/authschemes/oidcauth/oidc_auth.go
@@ -187,12 +187,12 @@ func (o OIDCAuth) handleCallback(w http.ResponseWriter, r *http.Request, bridge 
 		}
 
 		authData = authschemes.UserAuthData{
-			UserID:  userID,
-			UserKey: userProfile.Slug,
+			UserID:   userID,
+			Username: userProfile.Slug,
 		}
 		err = bridge.CreateNewAuthForUser(authData)
 		if err != nil {
-			return o.authFailure(w, r, backend.WrapError("Unable to create auth scheme for new "+authName+" user ["+authData.UserKey+"]", err), "/autherror/incomplete")
+			return o.authFailure(w, r, backend.WrapError("Unable to create auth scheme for new "+authName+" user ["+authData.Username+"]", err), "/autherror/incomplete")
 		}
 	}
 	if linkingAccount {
@@ -205,9 +205,9 @@ func (o OIDCAuth) handleCallback(w http.ResponseWriter, r *http.Request, bridge 
 	})
 	if err != nil {
 		if backend.IsErrorAccountDisabled(err) {
-			return o.authFailure(w, r, backend.WrapError("Unable to log in "+authName+" user ["+authData.UserKey+"]", err), "/autherror/disabled")
+			return o.authFailure(w, r, backend.WrapError("Unable to log in "+authName+" user ["+authData.Username+"]", err), "/autherror/disabled")
 		}
-		return o.authFailure(w, r, backend.WrapError("Unable to log in "+authName+" user ["+authData.UserKey+"]", err), "/autherror/incomplete")
+		return o.authFailure(w, r, backend.WrapError("Unable to log in "+authName+" user ["+authData.Username+"]", err), "/autherror/incomplete")
 	}
 	return o.authSuccess(w, r, linkingAccount)
 }

--- a/backend/authschemes/recoveryauth/helpers/helpers.go
+++ b/backend/authschemes/recoveryauth/helpers/helpers.go
@@ -24,8 +24,8 @@ func GenerateRecoveryCodeForUser(db *database.Connection, userID int64) (string,
 	authKeyStr := hex.EncodeToString(authKey)
 
 	err := GenerateNewRecoveryRecord(db, authschemes.UserAuthData{
-		UserID:  userID,
-		UserKey: authKeyStr,
+		UserID:   userID,
+		Username: authKeyStr,
 	})
 
 	return authKeyStr, err

--- a/backend/authschemes/recoveryauth/helpers/helpers_test.go
+++ b/backend/authschemes/recoveryauth/helpers/helpers_test.go
@@ -25,7 +25,7 @@ func TestGenerateRecoveryCodeForUser(t *testing.T) {
 		"auth_scheme": recoveryConsts.Code,
 		"user_id":     targetUserID,
 	}))
-	require.Equal(t, code, recoveryAuthEntry.UserKey)
+	require.Equal(t, code, recoveryAuthEntry.Username)
 }
 
 func setupDb(t *testing.T) *database.Connection {

--- a/backend/authschemes/recoveryauth/services_test.go
+++ b/backend/authschemes/recoveryauth/services_test.go
@@ -69,7 +69,7 @@ func TestDeleteExpiredRecoveryCodes(t *testing.T) {
 	recoveryRecords := getRecoveryRecords(t, db)
 
 	require.Equal(t, 1, len(recoveryRecords))
-	require.Equal(t, recoveryRecords[0].UserKey, validKeyName)
+	require.Equal(t, recoveryRecords[0].Username, validKeyName)
 }
 
 func createDummyRecoveryRecord(t *testing.T, db *database.Connection, key string, userID int64, age time.Duration) {

--- a/backend/authschemes/recoveryauth/services_test.go
+++ b/backend/authschemes/recoveryauth/services_test.go
@@ -76,7 +76,7 @@ func createDummyRecoveryRecord(t *testing.T, db *database.Connection, key string
 	_, err := db.Insert("auth_scheme_data", map[string]interface{}{
 		"auth_scheme": recoveryConsts.Code,
 		"auth_type":   recoveryConsts.Code,
-		"user_key":    key,
+		"username":    key,
 		"user_id":     userID,
 		"created_at":  time.Now().Add(-1 * age), // add negative time to emulate subtraction
 	})

--- a/backend/authschemes/webauthn/types.go
+++ b/backend/authschemes/webauthn/types.go
@@ -14,12 +14,14 @@ const (
 )
 
 type WebAuthnRegistrationInfo struct {
-	Email            string
-	FirstName        string
-	LastName         string
-	KeyName          string
-	UserID           int64
-	RegistrationType RegistrationType
+	Email               string
+	Username            string
+	FirstName           string
+	LastName            string
+	KeyName             string
+	UserID              int64
+	RegistrationType    RegistrationType
+	ExistingCredentials []AShirtWebauthnCredential
 }
 
 type AShirtWebauthnCredential struct {

--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -78,7 +78,13 @@ func (a WebAuthn) FriendlyName() string {
 }
 
 func (a WebAuthn) Flags() []string {
-	return []string{}
+	flags := make([]string, 0)
+
+	if a.RegistrationEnabled {
+		flags = append(flags, "open-registration")
+	}
+
+	return flags
 }
 
 func (a WebAuthn) Type() string {

--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -133,7 +133,7 @@ func (a WebAuthn) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge)
 
 		return nil, bridge.CreateNewAuthForUser(authschemes.UserAuthData{
 			UserID:   userResult.UserID,
-			UserKey:  data.UserData.UserName,
+			Username: data.UserData.UserName,
 			JSONData: helpers.Ptr(string(encodedCreds)),
 		})
 	}))
@@ -205,7 +205,7 @@ func (a WebAuthn) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge)
 		}
 		return nil, bridge.CreateNewAuthForUser(authschemes.UserAuthData{
 			UserID:   byteSliceToI64(data.UserData.UserID),
-			UserKey:  data.UserData.UserName,
+			Username: data.UserData.UserName,
 			JSONData: helpers.Ptr(string(encodedCreds)),
 		})
 	}))
@@ -239,7 +239,7 @@ func (a WebAuthn) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge)
 			}
 
 			info := WebAuthnRegistrationInfo{
-				Username:         auth.UserKey,
+				Username:         auth.Username,
 				KeyName:          keyName,
 				UserID:           auth.UserID,
 				RegistrationType: AddKey,

--- a/backend/authschemes/webauthn/webauthnuser.go
+++ b/backend/authschemes/webauthn/webauthnuser.go
@@ -20,10 +20,10 @@ type webauthnUser struct {
 	KeyName     string
 }
 
-func makeNewWebAuthnUser(firstName, lastName, email, keyName string) webauthnUser {
+func makeNewWebAuthnUser(firstName, lastName, email, username, keyName string) webauthnUser {
 	return webauthnUser{
 		UserID:    []byte(uuid.New().String()),
-		UserName:  email,
+		UserName:  username,
 		FirstName: firstName,
 		LastName:  lastName,
 		Email:     email,
@@ -31,25 +31,24 @@ func makeNewWebAuthnUser(firstName, lastName, email, keyName string) webauthnUse
 	}
 }
 
-func makeLinkingWebAuthnUser(userID int64, email, keyName string) webauthnUser {
+func makeLinkingWebAuthnUser(userID int64, username, keyName string) webauthnUser {
 	return webauthnUser{
 		UserID:   i64ToByteSlice(userID),
-		UserName: email,
-		Email:    email,
+		UserName: username,
 		KeyName:  keyName,
 	}
 }
 
-func makeAddKeyWebAuthnUser(userID int64, email, keyName string, creds []AShirtWebauthnCredential) webauthnUser {
-	user := makeLinkingWebAuthnUser(userID, email, keyName)
+func makeAddKeyWebAuthnUser(userID int64, username, keyName string, creds []AShirtWebauthnCredential) webauthnUser {
+	user := makeLinkingWebAuthnUser(userID, username, keyName)
 	user.Credentials = creds
 	return user
 }
 
-func makeWebAuthnUser(firstName, lastName, slug, email string, userID int64, creds []AShirtWebauthnCredential) webauthnUser {
+func makeWebAuthnUser(firstName, lastName, username, email string, userID int64, creds []AShirtWebauthnCredential) webauthnUser {
 	return webauthnUser{
 		UserID:      i64ToByteSlice(userID),
-		UserName:    slug,
+		UserName:    username,
 		Credentials: creds,
 		FirstName:   firstName,
 		LastName:    lastName,

--- a/backend/config/authconfig.go
+++ b/backend/config/authconfig.go
@@ -13,7 +13,7 @@ import (
 	"github.com/theparanoids/ashirt-server/backend/helpers"
 )
 
-// AuthConfig provides configuration details, namespaced to
+// AuthConfig provides configuration details for all authentication services
 type AuthConfig struct {
 	Services    []string
 	AuthConfigs map[string]AuthInstanceConfig

--- a/backend/config/authconfig.go
+++ b/backend/config/authconfig.go
@@ -105,11 +105,11 @@ func (w WebauthnConfig) AuthenticatorUserVerificationPreference() protocol.UserV
 
 func (w WebauthnConfig) BuildAuthenticatorSelection() protocol.AuthenticatorSelection {
 	return protocol.AuthenticatorSelection{
-			RequireResidentKey:      w.AuthenticatorRequireResidentKey,
-			UserVerification:        w.AuthenticatorUserVerificationPreference(),
-			ResidentKey:             w.AuthenticatorResidentKeyPreference(),
-			AuthenticatorAttachment: w.AuthenticatorAttachmentPreference(),
-		}
+		RequireResidentKey:      w.AuthenticatorRequireResidentKey,
+		UserVerification:        w.AuthenticatorUserVerificationPreference(),
+		ResidentKey:             w.AuthenticatorResidentKeyPreference(),
+		AuthenticatorAttachment: w.AuthenticatorAttachmentPreference(),
+	}
 }
 
 func splitNoSpaces(s, delimiter string) []string {

--- a/backend/database/seeding/seeder.go
+++ b/backend/database/seeding/seeder.go
@@ -101,7 +101,7 @@ func (seed Seeder) ApplyTo(db *database.Connection) error {
 				"id":                 seed.Users[i].ID,
 				"auth_scheme":        localConsts.Code,
 				"auth_type":          localConsts.Code,
-				"user_key":           seed.Users[i].FirstName,
+				"username":           seed.Users[i].FirstName,
 				"user_id":            seed.Users[i].ID,
 				"encrypted_password": encryptedPassword, //the user's first name, lowercased
 				"created_at":         seed.Users[i].CreatedAt,

--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -89,7 +89,7 @@ type UserOwnView struct {
 }
 
 type AuthenticationInfo struct {
-	UserKey        string               `json:"userKey"`
+	Username       string               `json:"username"`
 	AuthSchemeName *string              `json:"schemeName,omitempty"`
 	AuthSchemeCode string               `json:"schemeCode"`
 	AuthSchemeType string               `json:"schemeType"`

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -211,7 +211,7 @@ func DeprecationWarning(message string) error {
 	return WrapError(message, ErrorDeprecated)
 }
 
-func WebauthnLoginError(err error, logMessage... string) error {
+func WebauthnLoginError(err error, logMessage ...string) error {
 	var fullErr error
 	if len(logMessage) > 0 {
 		fullErr = WrapError(strings.Join(logMessage, " ; "), err)

--- a/backend/helpers/functional_test.go
+++ b/backend/helpers/functional_test.go
@@ -78,3 +78,21 @@ func TestFindMatch(t *testing.T) {
 	require.Nil(t, foundValue)
 	require.Equal(t, -1, index)
 }
+
+func TestFilter(t *testing.T) {
+	values := []int{1, 4, 9, 16, 25}
+	expectedValues := []int{1, 9, 25}
+
+	oddNumberFn := func(i int) bool {
+		return i%2 == 1
+	}
+	greaterThan100Fn := func(i int) bool {
+		return i > 100
+	}
+
+	actualResult := helpers.Filter(values, oddNumberFn)
+	require.Equal(t, expectedValues, actualResult)
+
+	actualResult = helpers.Filter(values, greaterThan100Fn)
+	require.Equal(t, []int{}, actualResult)
+}

--- a/backend/integration/helpers.go
+++ b/backend/integration/helpers.go
@@ -105,11 +105,12 @@ func (a *Tester) NewUser(slug string, firstName string, lastName string) *UserSe
 	a.Post("/web/auth/local/register").AsUser(session).WithMarshaledJSONBody(map[string]interface{}{
 		"firstName": firstName,
 		"lastName":  lastName,
+		"username":  slug,
 		"email":     strings.ToLower(slug) + "@example.com",
 		"password":  "password",
 	}).Do().ExpectSuccess()
 	a.Post("/web/auth/local/login").AsUser(session).WithMarshaledJSONBody(map[string]interface{}{
-		"email":    strings.ToLower(slug) + "@example.com",
+		"username":    slug,
 		"password": "password",
 	}).Do().ExpectSuccess()
 

--- a/backend/migrations/20220908193523-switch-to-username.sql
+++ b/backend/migrations/20220908193523-switch-to-username.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+ALTER TABLE `auth_scheme_data` CHANGE `user_key` `username` VARCHAR(255) NOT NULL;
+
+-- +migrate Down
+ALTER TABLE
+    `auth_scheme_data` CHANGE `username` `user_key` VARCHAR(255) NOT NULL;

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -150,7 +150,7 @@ type AuthSchemeData struct {
 	AuthScheme string `db:"auth_scheme"`
 	// AuthType defines how the scheme should work. e.g. "oidc" or "local"
 	AuthType          string     `db:"auth_type"`
-	UserKey           string     `db:"username"`
+	Username          string     `db:"username"`
 	UserID            int64      `db:"user_id"`
 	EncryptedPassword []byte     `db:"encrypted_password"`
 	MustResetPassword bool       `db:"must_reset_password"`

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -155,6 +155,7 @@ type AuthSchemeData struct {
 	EncryptedPassword []byte     `db:"encrypted_password"`
 	MustResetPassword bool       `db:"must_reset_password"`
 	TOTPSecret        *string    `db:"totp_secret"`
+	JSONData          *string    `db:"json_data"`
 	LastLogin         *time.Time `db:"last_login"`
 	CreatedAt         time.Time  `db:"created_at"`
 	UpdatedAt         *time.Time `db:"updated_at"`

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -150,7 +150,7 @@ type AuthSchemeData struct {
 	AuthScheme string `db:"auth_scheme"`
 	// AuthType defines how the scheme should work. e.g. "oidc" or "local"
 	AuthType          string     `db:"auth_type"`
-	UserKey           string     `db:"user_key"`
+	UserKey           string     `db:"username"`
 	UserID            int64      `db:"user_id"`
 	EncryptedPassword []byte     `db:"encrypted_password"`
 	MustResetPassword bool       `db:"must_reset_password"`

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -48,7 +48,7 @@ CREATE TABLE `auth_scheme_data` (
   `id` int NOT NULL AUTO_INCREMENT,
   `auth_scheme` varchar(255) NOT NULL,
   `auth_type` varchar(255) NOT NULL,
-  `user_key` varchar(255) DEFAULT NULL,
+  `username` varchar(255) NOT NULL,
   `user_id` int DEFAULT NULL,
   `encrypted_password` varbinary(255) DEFAULT NULL,
   `must_reset_password` tinyint(1) DEFAULT '0',
@@ -58,7 +58,7 @@ CREATE TABLE `auth_scheme_data` (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `auth_scheme_user_key` (`auth_scheme`,`user_key`),
+  UNIQUE KEY `auth_scheme_user_key` (`auth_scheme`,`username`),
   KEY `fk_user_id__users_id` (`user_id`),
   CONSTRAINT `fk_user_id__users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -411,7 +411,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-08-11 16:15:51
+-- Dump completed on 2022-09-08 19:38:20
 -- MySQL dump 10.13  Distrib 8.0.22, for Linux (x86_64)
 --
 -- Host: localhost    Database: migrate_db
@@ -435,7 +435,7 @@ CREATE TABLE `users` (
 
 LOCK TABLES `gorp_migrations` WRITE;
 /*!40000 ALTER TABLE `gorp_migrations` DISABLE KEYS */;
-INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2022-08-11 16:15:47'),('20190708185420-create-operations-table.sql','2022-08-11 16:15:47'),('20190708185427-create-events-table.sql','2022-08-11 16:15:47'),('20190708185432-create-evidence-table.sql','2022-08-11 16:15:47'),('20190708185441-create-evidence-event-map-table.sql','2022-08-11 16:15:47'),('20190716190100-create-user-operation-map-table.sql','2022-08-11 16:15:47'),('20190722193434-create-tags-table.sql','2022-08-11 16:15:47'),('20190722193937-create-tag-event-map.sql','2022-08-11 16:15:47'),('20190909183500-add-short-name-to-users-table.sql','2022-08-11 16:15:47'),('20190909190416-add-short-name-index.sql','2022-08-11 16:15:47'),('20190926205116-evidence-name.sql','2022-08-11 16:15:48'),('20190930173342-add-saved-searches.sql','2022-08-11 16:15:48'),('20191001182541-evidence-tags.sql','2022-08-11 16:15:48'),('20191008005212-add-uuid-to-events-evidence.sql','2022-08-11 16:15:48'),('20191015235306-add-slug-to-operations.sql','2022-08-11 16:15:48'),('20191018172105-modular-auth.sql','2022-08-11 16:15:49'),('20191023170906-codeblock.sql','2022-08-11 16:15:49'),('20191101185207-replace-events-with-findings.sql','2022-08-11 16:15:49'),('20191114211948-add-operation-to-tags.sql','2022-08-11 16:15:49'),('20191205182830-create-api-keys-table.sql','2022-08-11 16:15:49'),('20191213222629-users-with-email.sql','2022-08-11 16:15:49'),('20200103194053-rename-short-name-to-slug.sql','2022-08-11 16:15:49'),('20200104013804-rework-ashirt-auth.sql','2022-08-11 16:15:49'),('20200116070736-add-admin-flag.sql','2022-08-11 16:15:50'),('20200130175541-fix-color-truncation.sql','2022-08-11 16:15:50'),('20200205200208-disable-user-support.sql','2022-08-11 16:15:50'),('20200215015330-optional-user-id.sql','2022-08-11 16:15:50'),('20200221195107-deletable-user.sql','2022-08-11 16:15:50'),('20200303215004-move-last-login.sql','2022-08-11 16:15:50'),('20200306221628-add-explicit-headless.sql','2022-08-11 16:15:50'),('20200331155258-finding-status.sql','2022-08-11 16:15:50'),('20200617193248-case-senitive-apikey.sql','2022-08-11 16:15:50'),('20200928160958-add-totp-secret-to-auth-table.sql','2022-08-11 16:15:51'),('20210120205510-create-email-queue-table.sql','2022-08-11 16:15:51'),('20210401220807-dynamic-categories.sql','2022-08-11 16:15:51'),('20210408212206-remove-findings-category.sql','2022-08-11 16:15:51'),('20210730170543-add-auth-type.sql','2022-08-11 16:15:51'),('20220211181557-add-default-tags.sql','2022-08-11 16:15:51'),('20220512174013-evidence-metadata.sql','2022-08-11 16:15:51'),('20220516163424-add-worker-services.sql','2022-08-11 16:15:51'),('20220811153414-webauthn-credentials.sql','2022-08-11 16:15:51');
+INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2022-09-08 19:38:17'),('20190708185420-create-operations-table.sql','2022-09-08 19:38:17'),('20190708185427-create-events-table.sql','2022-09-08 19:38:17'),('20190708185432-create-evidence-table.sql','2022-09-08 19:38:17'),('20190708185441-create-evidence-event-map-table.sql','2022-09-08 19:38:17'),('20190716190100-create-user-operation-map-table.sql','2022-09-08 19:38:17'),('20190722193434-create-tags-table.sql','2022-09-08 19:38:17'),('20190722193937-create-tag-event-map.sql','2022-09-08 19:38:17'),('20190909183500-add-short-name-to-users-table.sql','2022-09-08 19:38:17'),('20190909190416-add-short-name-index.sql','2022-09-08 19:38:17'),('20190926205116-evidence-name.sql','2022-09-08 19:38:17'),('20190930173342-add-saved-searches.sql','2022-09-08 19:38:18'),('20191001182541-evidence-tags.sql','2022-09-08 19:38:18'),('20191008005212-add-uuid-to-events-evidence.sql','2022-09-08 19:38:18'),('20191015235306-add-slug-to-operations.sql','2022-09-08 19:38:18'),('20191018172105-modular-auth.sql','2022-09-08 19:38:18'),('20191023170906-codeblock.sql','2022-09-08 19:38:18'),('20191101185207-replace-events-with-findings.sql','2022-09-08 19:38:18'),('20191114211948-add-operation-to-tags.sql','2022-09-08 19:38:18'),('20191205182830-create-api-keys-table.sql','2022-09-08 19:38:19'),('20191213222629-users-with-email.sql','2022-09-08 19:38:19'),('20200103194053-rename-short-name-to-slug.sql','2022-09-08 19:38:19'),('20200104013804-rework-ashirt-auth.sql','2022-09-08 19:38:19'),('20200116070736-add-admin-flag.sql','2022-09-08 19:38:19'),('20200130175541-fix-color-truncation.sql','2022-09-08 19:38:19'),('20200205200208-disable-user-support.sql','2022-09-08 19:38:19'),('20200215015330-optional-user-id.sql','2022-09-08 19:38:19'),('20200221195107-deletable-user.sql','2022-09-08 19:38:19'),('20200303215004-move-last-login.sql','2022-09-08 19:38:19'),('20200306221628-add-explicit-headless.sql','2022-09-08 19:38:19'),('20200331155258-finding-status.sql','2022-09-08 19:38:19'),('20200617193248-case-senitive-apikey.sql','2022-09-08 19:38:19'),('20200928160958-add-totp-secret-to-auth-table.sql','2022-09-08 19:38:19'),('20210120205510-create-email-queue-table.sql','2022-09-08 19:38:20'),('20210401220807-dynamic-categories.sql','2022-09-08 19:38:20'),('20210408212206-remove-findings-category.sql','2022-09-08 19:38:20'),('20210730170543-add-auth-type.sql','2022-09-08 19:38:20'),('20220211181557-add-default-tags.sql','2022-09-08 19:38:20'),('20220512174013-evidence-metadata.sql','2022-09-08 19:38:20'),('20220516163424-add-worker-services.sql','2022-09-08 19:38:20'),('20220811153414-webauthn-credentials.sql','2022-09-08 19:38:20'),('20220908193523-switch-to-username.sql','2022-09-08 19:38:20');
 /*!40000 ALTER TABLE `gorp_migrations` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -448,4 +448,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-08-11 16:15:51
+-- Dump completed on 2022-09-08 19:38:20

--- a/backend/server/middleware/api_key_internal_test.go
+++ b/backend/server/middleware/api_key_internal_test.go
@@ -69,7 +69,7 @@ func TestAuthenticateAPI(t *testing.T) {
 	keyData := createAPIKey(t, db, userID)
 
 	disabledUser := createDummyUser(t, db, models.User{Slug: "snail", FirstName: "fn", LastName: "ln", Email: "disabledUser@example.com", Disabled: true})
-	disabledUserKeys := createAPIKey(t, db, disabledUser)
+	disabledUsernames := createAPIKey(t, db, disabledUser)
 
 	browser := testBrowser{}
 	newReq := func() (*http.Request, io.Reader) {
@@ -93,7 +93,7 @@ func TestAuthenticateAPI(t *testing.T) {
 	require.Error(t, badKeys)
 
 	req, reader = newReq()
-	addGoodHeaders(t, req, disabledUserKeys.AccessKey, disabledUserKeys.SecretKey)
+	addGoodHeaders(t, req, disabledUsernames.AccessKey, disabledUsernames.SecretKey)
 	_, disabledUserError := authenticateAPI(db, req, reader)
 	require.Equal(t, backend.DisabledUserError(), disabledUserError)
 

--- a/backend/services/auth_scheme_test.go
+++ b/backend/services/auth_scheme_test.go
@@ -30,7 +30,7 @@ func TestDeleteAuthScheme(t *testing.T) {
 			return map[string]interface{}{
 				"auth_scheme": recoveryScheme,
 				"auth_type":   recoveryScheme,
-				"user_key":    users[i].FirstName,
+				"username":    users[i].FirstName,
 				"user_id":     users[i].ID,
 			}
 		})
@@ -50,7 +50,7 @@ func TestDeleteAuthScheme(t *testing.T) {
 		_, err = db.Insert("auth_scheme_data", map[string]interface{}{
 			"auth_scheme": schemeName,
 			"auth_type":   schemeName,
-			"user_key":    normalUser.FirstName,
+			"username":    normalUser.FirstName,
 			"user_id":     normalUser.ID,
 		})
 		require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestListAuthDetailsKeys(t *testing.T) {
 		// Add in an unsupported scheme
 		_, err = db.Insert("auth_scheme_data", map[string]interface{}{
 			"auth_scheme": darkMarkScheme.SchemeCode,
-			"user_key":    "Half-Blood Prince",
+			"username":    "Half-Blood Prince",
 			"user_id":     UserSnape.ID,
 			"auth_type":   darkMarkScheme.SchemeType,
 		})

--- a/backend/services/user.go
+++ b/backend/services/user.go
@@ -430,7 +430,7 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string, sup
 		index := getMatchingSchemeIndex(supportedAuthSchemes, v.AuthScheme)
 
 		auths[i] = dtos.AuthenticationInfo{
-			UserKey:        v.UserKey,
+			Username:       v.Username,
 			AuthSchemeCode: v.AuthScheme,
 			AuthSchemeType: v.AuthType,
 			AuthLogin:      v.LastLogin,

--- a/backend/services/user.go
+++ b/backend/services/user.go
@@ -414,7 +414,7 @@ func ReadUser(ctx context.Context, db *database.Connection, userSlug string, sup
 			From("users").
 			Where(sq.Eq{"id": userID}))
 
-		db.Select(&authSchemes, sq.Select("user_key", "auth_scheme", "auth_type", "last_login").
+		db.Select(&authSchemes, sq.Select("username", "auth_scheme", "auth_type", "last_login").
 			From("auth_scheme_data").
 			Where(sq.Eq{
 				"user_id":     userID,

--- a/frontend/src/authschemes/index.tsx
+++ b/frontend/src/authschemes/index.tsx
@@ -8,7 +8,7 @@ import { SupportedAuthenticationScheme, UserOwnView } from "src/global_types"
 export type AuthFrontend = {
   Linker: React.FunctionComponent<{ onSuccess: () => void, authFlags?: Array<string>, userData: UserOwnView }>,
   Login: React.FunctionComponent<{ query: URLSearchParams, authFlags?: Array<string> }>,
-  Settings: React.FunctionComponent<{ userKey: string, authFlags?: Array<string> }>,
+  Settings: React.FunctionComponent<{ username: string, authFlags?: Array<string> }>,
 }
 
 // @ts-ignore - this is a webpack compile-time include of src/authschemes/*/index.ts

--- a/frontend/src/authschemes/local/linker/index.tsx
+++ b/frontend/src/authschemes/local/linker/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020, Verizon Media
+// Copyright 2022, Yahoo Inc.
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
@@ -7,12 +7,15 @@ import { useForm, useFormField } from 'src/helpers'
 
 import Form from 'src/components/form'
 import Input from 'src/components/input'
+import { UserOwnView } from 'src/global_types'
 
 export default (props: {
   onSuccess: () => void,
+  userData: UserOwnView
   authFlags?: Array<string>,
 }) => {
-  const username = useFormField<string>('')
+  const initialUsername = props.userData.authSchemes.find(s => s.schemeType == 'webauthn')?.userKey
+  const username = useFormField<string>(initialUsername ?? "")
   const password = useFormField<string>('')
   const confirmPassword = useFormField<string>('')
 
@@ -35,9 +38,11 @@ export default (props: {
     }
   })
 
+  const readonlyUsername = initialUsername !== undefined
+
   return (
     <Form submitText="Link Account" {...formComponentProps}>
-      <Input label="Username" {...username} />
+      <Input label="Username" {...username} readOnly={readonlyUsername} />
       <Input type="password" label="Password" {...password} />
       <Input type="password" label="Confirm Password" {...confirmPassword} />
     </Form>

--- a/frontend/src/authschemes/local/linker/index.tsx
+++ b/frontend/src/authschemes/local/linker/index.tsx
@@ -12,7 +12,7 @@ export default (props: {
   onSuccess: () => void,
   authFlags?: Array<string>,
 }) => {
-  const email = useFormField<string>('')
+  const username = useFormField<string>('')
   const password = useFormField<string>('')
   const confirmPassword = useFormField<string>('')
 
@@ -20,15 +20,15 @@ export default (props: {
     fields: [password, confirmPassword],
     onSuccess: () => props.onSuccess(),
     handleSubmit: () => {
-      if (email.value === '') {
-        return Promise.reject("Email must be populated")
+      if (username.value === '') {
+        return Promise.reject("Username must be populated")
       }
       if (password.value === '') {
         return Promise.reject("Password must be populated")
       }
 
       return linkLocalAccount({
-        email: email.value,
+        username: username.value,
         password: password.value,
         confirmPassword: confirmPassword.value
       })
@@ -37,7 +37,7 @@ export default (props: {
 
   return (
     <Form submitText="Link Account" {...formComponentProps}>
-      <Input label="Email" {...email} />
+      <Input label="Username" {...username} />
       <Input type="password" label="Password" {...password} />
       <Input type="password" label="Confirm Password" {...confirmPassword} />
     </Form>

--- a/frontend/src/authschemes/local/linker/index.tsx
+++ b/frontend/src/authschemes/local/linker/index.tsx
@@ -14,7 +14,7 @@ export default (props: {
   userData: UserOwnView
   authFlags?: Array<string>,
 }) => {
-  const initialUsername = props.userData.authSchemes.find(s => s.schemeType == 'webauthn')?.userKey
+  const initialUsername = props.userData.authSchemes.find(s => s.schemeType == 'webauthn')?.username
   const username = useFormField<string>(initialUsername ?? "")
   const password = useFormField<string>('')
   const confirmPassword = useFormField<string>('')

--- a/frontend/src/authschemes/local/login/index.tsx
+++ b/frontend/src/authschemes/local/login/index.tsx
@@ -52,13 +52,13 @@ export default (props: {
 const Login = (props: {
   authFlags?: Array<string>
 }) => {
-  const emailField = useFormField('')
+  const usernameField = useFormField('')
   const passwordField = useFormField('')
 
   const loginForm = useForm({
-    fields: [emailField, passwordField],
+    fields: [usernameField, passwordField],
     handleSubmit: () => (
-      handleLoginStepPromise(login(emailField.value, getValueAndClear(passwordField)))
+      handleLoginStepPromise(login(usernameField.value, getValueAndClear(passwordField)))
     ),
   })
 
@@ -72,7 +72,7 @@ const Login = (props: {
   return (
     <div style={{ minWidth: 300 }}>
       <Form submitText="Login" {...registerProps} {...loginForm}>
-        <Input label="Email" {...emailField} />
+        <Input label="Username" {...usernameField} />
         <Input label="Password" type="password" {...passwordField} />
       </Form>
       <div className={cx('recover-container')}>
@@ -88,6 +88,7 @@ const RegisterModal = (props: {
 }) => {
   const firstNameField = useFormField('')
   const lastNameField = useFormField('')
+  const usernameField = useFormField('')
   const emailField = useFormField('')
   const passwordField = useFormField('')
   const confirmPasswordField = useFormField('')
@@ -96,6 +97,7 @@ const RegisterModal = (props: {
     fields: [
       firstNameField,
       lastNameField,
+      usernameField,
       emailField,
       passwordField,
       confirmPasswordField,
@@ -104,6 +106,7 @@ const RegisterModal = (props: {
       await register({
         firstName: firstNameField.value,
         lastName: lastNameField.value,
+        username: usernameField.value,
         email: emailField.value,
         password: getValueAndClear(passwordField),
         confirmPassword: getValueAndClear(confirmPasswordField),
@@ -117,7 +120,8 @@ const RegisterModal = (props: {
       <Form submitText="Create Account" {...registerForm}>
         <Input label="First Name" {...firstNameField} />
         <Input label="Last Name" {...lastNameField} />
-        <Input label="Email" {...emailField} />
+        <Input label="Contact Email" {...emailField} />
+        <Input label="Desired Username" {...usernameField} />
         <Input label="Password" type="password" {...passwordField} />
         <Input label="Confirm Password" type="password" {...confirmPasswordField} />
       </Form>
@@ -185,7 +189,7 @@ const RecoverUserAccount = (props: {}) => {
   return (<>
     <h2 className={cx('title')}>Find Your Account</h2>
     <Form submitText="Submit" {...emailForm}>
-      <Input label="Email" {...emailField} />
+      <Input label="Contact Email" {...emailField} />
     </Form>
   </>)
 }

--- a/frontend/src/authschemes/local/services.ts
+++ b/frontend/src/authschemes/local/services.ts
@@ -33,7 +33,7 @@ export async function userResetPassword(i: {
 }
 
 export async function userChangePassword(i: {
-  userKey: string,
+  username: string,
   oldPassword: string,
   newPassword: string,
   confirmPassword: string,

--- a/frontend/src/authschemes/local/services.ts
+++ b/frontend/src/authschemes/local/services.ts
@@ -1,17 +1,18 @@
 import req from 'src/services/data_sources/backend/request_helper'
 
-export async function login(email: string, password: string) {
-  await req('POST', '/auth/local/login', { email, password })
+export async function login(username: string, password: string) {
+  await req('POST', '/auth/local/login', { username, password })
 }
 
-export async function requestRecovery(email:string) {
-  await req('POST', '/auth/recovery/generateemail', {userEmail: email})
+export async function requestRecovery(email: string) {
+  await req('POST', '/auth/recovery/generateemail', { userEmail: email })
 }
 
 export async function register(i: {
   firstName: string,
   lastName: string,
   email: string,
+  username: string,
   password: string,
   confirmPassword: string,
 }) {
@@ -44,7 +45,7 @@ export async function userChangePassword(i: {
 }
 
 export async function linkLocalAccount(i: {
-  email: string
+  username: string
   password: string,
   confirmPassword: string
 }) {

--- a/frontend/src/authschemes/local/settings/index.tsx
+++ b/frontend/src/authschemes/local/settings/index.tsx
@@ -12,18 +12,18 @@ import Totp from '../totp'
 const cx = classnames.bind(require('./stylesheet'))
 
 export default (props: {
-  userKey: string,
+  username: string,
   authFlags?: Array<string>
 }) => <>
-  <h1 className={cx('header')}>Settings for local account <span className={cx('user-key')}>{props.userKey}</span></h1>
-  <SettingsSection title="Change Password" width="narrow">
-    <ResetPasswordForm userKey={props.userKey} />
-  </SettingsSection>
-  <Totp />
-</>
+    <h1 className={cx('header')}>Settings for local account <span className={cx('user-key')}>{props.username}</span></h1>
+    <SettingsSection title="Change Password" width="narrow">
+      <ResetPasswordForm username={props.username} />
+    </SettingsSection>
+    <Totp />
+  </>
 
 const ResetPasswordForm = (props: {
-  userKey: string,
+  username: string,
 }) => {
   const oldPassword = useFormField('')
   const newPassword = useFormField('')
@@ -33,7 +33,7 @@ const ResetPasswordForm = (props: {
     fields: [oldPassword, newPassword, confirmPassword],
     handleSubmit: () => {
       return userChangePassword({
-        userKey: props.userKey,
+        username: props.username,
         oldPassword: oldPassword.value,
         newPassword: newPassword.value,
         confirmPassword: confirmPassword.value,

--- a/frontend/src/authschemes/local/settings/index.tsx
+++ b/frontend/src/authschemes/local/settings/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020, Verizon Media
+// Copyright 2022, Yahoo Inc.
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
@@ -14,14 +14,15 @@ const cx = classnames.bind(require('./stylesheet'))
 export default (props: {
   username: string,
   authFlags?: Array<string>
-}) => <>
+}) => (
+  <>
     <h1 className={cx('header')}>Settings for local account <span className={cx('user-key')}>{props.username}</span></h1>
     <SettingsSection title="Change Password" width="narrow">
       <ResetPasswordForm username={props.username} />
     </SettingsSection>
     <Totp />
   </>
-
+)
 const ResetPasswordForm = (props: {
   username: string,
 }) => {

--- a/frontend/src/authschemes/webauthn/linker/index.tsx
+++ b/frontend/src/authschemes/webauthn/linker/index.tsx
@@ -15,7 +15,7 @@ export default (props: {
   userData: UserOwnView
   authFlags?: Array<string>,
 }) => {
-  const initialUsername = props.userData.authSchemes.find(s => s.schemeType == 'local')?.userKey
+  const initialUsername = props.userData.authSchemes.find(s => s.schemeType == 'local')?.username
   const username = useFormField<string>(initialUsername ?? "")
   const keyName = useFormField<string>('')
 

--- a/frontend/src/authschemes/webauthn/linker/index.tsx
+++ b/frontend/src/authschemes/webauthn/linker/index.tsx
@@ -15,22 +15,22 @@ export default (props: {
   userData: UserOwnView
   authFlags?: Array<string>,
 }) => {
-  const email = useFormField<string>(props.userData.email)
+  const username = useFormField<string>(props.userData.email)
   const keyName = useFormField<string>('')
 
   const formComponentProps = useForm({
-    fields: [email, keyName],
+    fields: [username, keyName],
     onSuccess: () => props.onSuccess(),
     handleSubmit: async () => {
-      if (email.value === '') {
-        return Promise.reject(new Error("Email must be populated"))
+      if (username.value === '') {
+        return Promise.reject(new Error("Username must be populated"))
       }
       if (keyName.value === '') {
         return Promise.reject(new Error("Key name must be populated"))
       }
 
       const reg = await beginLink({
-        email: email.value,
+        username: username.value,
         keyName: keyName.value,
       })
       const credOptions = convertToCredentialCreationOptions(reg)
@@ -57,7 +57,7 @@ export default (props: {
 
   return (
     <Form submitText="Link Account" {...formComponentProps}>
-      <Input label="Email" {...email} readOnly />
+      <Input label="Username" {...username} readOnly />
       <Input label="Key name" {...keyName} />
     </Form>
   )

--- a/frontend/src/authschemes/webauthn/linker/index.tsx
+++ b/frontend/src/authschemes/webauthn/linker/index.tsx
@@ -15,7 +15,8 @@ export default (props: {
   userData: UserOwnView
   authFlags?: Array<string>,
 }) => {
-  const username = useFormField<string>(props.userData.email)
+  const initialUsername = props.userData.authSchemes.find(s => s.schemeType == 'local')?.userKey
+  const username = useFormField<string>(initialUsername ?? "")
   const keyName = useFormField<string>('')
 
   const formComponentProps = useForm({
@@ -55,9 +56,11 @@ export default (props: {
     }
   })
 
+  const readonlyUsername = initialUsername !== undefined
+
   return (
     <Form submitText="Link Account" {...formComponentProps}>
-      <Input label="Username" {...username} readOnly />
+      <Input label="Username" {...username} readOnly={readonlyUsername} />
       <Input label="Key name" {...keyName} />
     </Form>
   )

--- a/frontend/src/authschemes/webauthn/login/index.tsx
+++ b/frontend/src/authschemes/webauthn/login/index.tsx
@@ -24,12 +24,12 @@ export default (props: {
 const Login = (props: {
   authFlags?: Array<string>
 }) => {
-  const emailField = useFormField('')
+  const usernameField = useFormField('')
 
   const loginForm = useForm({
-    fields: [emailField],
+    fields: [usernameField],
     handleSubmit: async () => {
-      const protoOptions = await beginLogin({ email: emailField.value })
+      const protoOptions = await beginLogin({ username: usernameField.value })
       const credOptions = convertToPublicKeyCredentialRequestOptions(protoOptions)
 
       const cred = await navigator.credentials.get({
@@ -52,16 +52,13 @@ const Login = (props: {
           userHandle: pubKeyResponse.userHandle == null ? "" : encodeAsB64(pubKeyResponse.userHandle),
         }
       })
-      window.location.pathname = '/' // TODO: is this what we want to do?
+      window.location.pathname = '/'
     },
   })
 
   const registerModal = useModal<void>(modalProps => <RegisterModal {...(modalProps as OnRequestClose)} />)
 
-  const allowRegister = props.authFlags?.includes("open-registration")
-  // const registerProps = allowRegister
-  //   ? { cancelText: "Register", onCancel: () => registerModal.show() }
-  //   : {}
+  const allowRegister = props.authFlags?.includes("open-registration") // TODO: this isn't being used
 
   const registerProps = { cancelText: "Register", onCancel: () => registerModal.show() }
 
@@ -70,7 +67,7 @@ const Login = (props: {
       {window.PublicKeyCredential && (
         <div style={{ minWidth: 300 }}>
           <Form submitText="Login with WebAuthN" {...registerProps} {...loginForm}>
-            <Input label="Email" {...emailField} />
+            <Input label="Username" {...usernameField} />
           </Form>
           {renderModals(registerModal)}
         </div>
@@ -85,6 +82,7 @@ const RegisterModal = (props: {
   const firstNameField = useFormField('')
   const lastNameField = useFormField('')
   const emailField = useFormField('')
+  const usernameField = useFormField('')
   const keyNameField = useFormField('')
 
   const registerForm = useForm({
@@ -93,6 +91,7 @@ const RegisterModal = (props: {
       firstNameField,
       lastNameField,
       emailField,
+      usernameField,
       keyNameField,
     ],
     handleSubmit: async () => {
@@ -104,6 +103,7 @@ const RegisterModal = (props: {
         firstName: firstNameField.value,
         lastName: lastNameField.value,
         email: emailField.value,
+        username: usernameField.value,
         keyName: keyNameField.value,
       })
       const credOptions = convertToCredentialCreationOptions(reg)
@@ -137,6 +137,7 @@ const RegisterModal = (props: {
         <Input label="First Name" {...firstNameField} />
         <Input label="Last Name" {...lastNameField} />
         <Input label="Email" {...emailField} />
+        <Input label="Desired Username" {...usernameField} />
         <Input label="Key Name" {...keyNameField} />
       </Form>
     </Modal>

--- a/frontend/src/authschemes/webauthn/login/index.tsx
+++ b/frontend/src/authschemes/webauthn/login/index.tsx
@@ -60,7 +60,9 @@ const Login = (props: {
 
   const allowRegister = props.authFlags?.includes("open-registration") // TODO: this isn't being used
 
-  const registerProps = { cancelText: "Register", onCancel: () => registerModal.show() }
+  const registerProps = allowRegister
+    ? { cancelText: "Register", onCancel: () => registerModal.show() }
+    : {}
 
   return (
     <div>

--- a/frontend/src/authschemes/webauthn/services.ts
+++ b/frontend/src/authschemes/webauthn/services.ts
@@ -13,6 +13,7 @@ import {
 
 export async function beginRegistration(i: {
   email: string,
+  username: string,
   firstName: string,
   lastName: string
   keyName: string
@@ -25,7 +26,7 @@ export async function finishRegistration(i: WebAuthNRegisterConfirmation) {
 }
 
 export async function beginLogin(i: {
-  email: string,
+  username: string,
 }): Promise<ProvidedCredentialRequestOptions> {
   return await req('POST', '/auth/webauthn/login/begin', i)
 }
@@ -35,7 +36,7 @@ export async function finishLogin(i: CompletedLoginChallenge): Promise<void> {
 }
 
 export async function beginLink(i: {
-  email: string,
+  username: string,
   keyName: string
 }): Promise<ProvidedCredentialCreationOptions> {
   return await req('POST', '/auth/webauthn/link/begin', i)

--- a/frontend/src/authschemes/webauthn/services.ts
+++ b/frontend/src/authschemes/webauthn/services.ts
@@ -56,10 +56,10 @@ export async function finishAddKey(i: WebAuthNRegisterConfirmation) {
   return await req('POST', '/auth/webauthn/key/add/finish', i)
 }
 
-export async function listUserKeys(): Promise<KeyList> {
+export async function listWebauthnKeys(): Promise<KeyList> {
   return await req('GET', '/auth/webauthn/keys')
 }
 
-export async function deleteUserKey(i: {keyName: string}): Promise<KeyList> {
+export async function deleteWebauthnKey(i: { keyName: string }): Promise<KeyList> {
   return await req('DELETE', `/auth/webauthn/key/${i.keyName}`)
 }

--- a/frontend/src/authschemes/webauthn/settings/index.tsx
+++ b/frontend/src/authschemes/webauthn/settings/index.tsx
@@ -7,7 +7,7 @@ import SettingsSection from 'src/components/settings_section'
 import classnames from 'classnames/bind'
 import { useForm, useFormField } from 'src/helpers/use_form'
 import { renderModals, useModal, useWiredData } from 'src/helpers'
-import { beginAddKey, deleteUserKey, finishAddKey, listUserKeys } from '../services'
+import { beginAddKey, deleteWebauthnKey, finishAddKey, listWebauthnKeys } from '../services'
 import Table from 'src/components/table'
 import Button from 'src/components/button'
 import { BuildReloadBus } from 'src/helpers/reload_bus'
@@ -17,7 +17,7 @@ import ChallengeModalForm from 'src/components/challenge_modal_form'
 const cx = classnames.bind(require('./stylesheet'))
 
 export default (props: {
-  userKey: string,
+  username: string,
   authFlags?: Array<string>
 }) => {
   const bus = BuildReloadBus()
@@ -33,14 +33,14 @@ const KeyList = (props: {
   onReload: (listener: () => void) => void
   offReload: (listener: () => void) => void
 }) => {
-  const wiredKeys = useWiredData(listUserKeys)
+  const wiredKeys = useWiredData(listWebauthnKeys)
 
   React.useEffect(() => {
     props.onReload(wiredKeys.reload)
     return () => { props.offReload(wiredKeys.reload) }
   })
 
-  const deleteModal = useModal<{keyName: string}>(mProps => <DeleteKeyModal {...mProps}/>, wiredKeys.reload)
+  const deleteModal = useModal<{ keyName: string }>(mProps => <DeleteKeyModal {...mProps} />, wiredKeys.reload)
 
   return (<>
     {wiredKeys.render(data => {
@@ -52,7 +52,7 @@ const KeyList = (props: {
                 <tr key={key}>
                   <td>{key}</td>
                   <td><Button small danger onClick={() => {
-                    deleteModal.show({keyName: key})
+                    deleteModal.show({ keyName: key })
                   }}>Delete</Button></td>
                 </tr>
               )
@@ -87,7 +87,7 @@ const AddKeyModal = (props: {
 
   const formComponentProps = useForm({
     fields: [keyName],
-    handleSubmit: async() => {
+    handleSubmit: async () => {
       if (keyName.value === '') {
         return Promise.reject(new Error("Key name must be populated"))
       }
@@ -139,7 +139,7 @@ const DeleteKeyModal = (props: {
     warningText="Are you sure you want to delete this security key?"
     submitText="Delete"
     challengeText={props.keyName}
-    handleSubmit={() => deleteUserKey({ keyName: props.keyName })}
+    handleSubmit={() => deleteWebauthnKey({ keyName: props.keyName })}
     onRequestClose={props.onRequestClose}
   />
 )

--- a/frontend/src/global_types.ts
+++ b/frontend/src/global_types.ts
@@ -171,7 +171,7 @@ export type UserWithAuth = User & {
 }
 
 export type AuthenticationInfo = {
-  userKey: string,
+  username: string,
   schemeName: string | undefined,
   schemeCode: string,
   schemeType: string,

--- a/frontend/src/pages/account_settings/profile/index.tsx
+++ b/frontend/src/pages/account_settings/profile/index.tsx
@@ -35,7 +35,7 @@ export default (props: {
       <Form submitText="Update Profile" {...profileForm}>
         <Input name="firstName" label="First Name" {...firstNameField} />
         <Input name="lastName" label="Last Name" {...lastNameField} />
-        <Input name="contactEmail" label="Contact Email" {...emailField} />
+        <Input type="email" name="contactEmail" label="Contact Email" {...emailField} />
       </Form>
     </SettingsSection>
   )

--- a/frontend/src/pages/account_settings/security/index.tsx
+++ b/frontend/src/pages/account_settings/security/index.tsx
@@ -17,7 +17,7 @@ export default (props: {
         key={authScheme.schemeCode}
         authSchemeDetails={authScheme.authDetails}
         authSchemeType={authScheme.schemeType}
-        userKey={authScheme.userKey}
+        username={authScheme.username}
       />
     ))}
   </>
@@ -26,10 +26,10 @@ export default (props: {
 const AuthSchemeSettings = (props: {
   authSchemeDetails?: SupportedAuthenticationScheme
   authSchemeType: string,
-  userKey: string,
+  username: string,
 }) => {
   const Settings = useAuthFrontendComponent(props.authSchemeType, 'Settings', props.authSchemeDetails)
   return (
-    <Settings userKey={props.userKey} authFlags={props.authSchemeDetails?.schemeFlags || []} />
+    <Settings username={props.username} authFlags={props.authSchemeDetails?.schemeFlags || []} />
   )
 }

--- a/frontend/src/pages/admin_modals/index.tsx
+++ b/frontend/src/pages/admin_modals/index.tsx
@@ -96,8 +96,8 @@ export const AddHeadlessUserModal = (props: {
       {...formComponentProps}
       disableSubmit={apiKey != null}
     >
-      <Input label="Headless name" {...headlessName} />
-      <Input type="email" label="Contact Email" {...contactEmail} />
+      <Input label="Headless name" {...headlessName} disabled={apiKey != null} />
+      <Input type="email" label="Contact Email" {...contactEmail} disabled={apiKey != null} />
       <Checkbox label="Also create API key" {...doCreateApiKey} />
       {
         apiKey && <NewApiKeyModalContents apiKey={apiKey} />
@@ -131,13 +131,12 @@ export const AddUserModal = (props: {
       if (contactEmail.value.length == 0) {
         return new Promise((_resolve, reject) => reject(Error("Users must have an email address")))
       }
-      // TODO: this should create the user, then update the form with the new user/password combo
-      // to share.
       const runSubmit = async () => {
         const result = await adminCreateLocalUser({
           firstName: firstName.value,
           lastName: lastName.value,
           email: contactEmail.value,
+          username: contactEmail.value,
         })
         setUsername(contactEmail.value)
         setPassword(result.temporaryPassword)
@@ -155,7 +154,7 @@ export const AddUserModal = (props: {
       >
         <Input label="First Name" {...firstName} disabled={isDisabled} />
         <Input label="Last Name" {...lastName} disabled={isDisabled} />
-        <Input label="Email" {...contactEmail} disabled={isDisabled} />
+        <Input type="email" label="Email" {...contactEmail} disabled={isDisabled} />
       </Form>
       {isDisabled && (<>
         <div className={cx('success-area')}>
@@ -296,7 +295,7 @@ export const InviteUserModal = (props: {
       >
         <Input label="First Name" {...firstName} disabled={isDisabled} />
         <Input label="Last Name" {...lastName} disabled={isDisabled} />
-        <Input label="Email" {...contactEmail} disabled={isDisabled} />
+        <Input type="email" label="Email" {...contactEmail} disabled={isDisabled} />
       </Form>
       {isDisabled && (<>
         <div className={cx('success-area')}>

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -33,6 +33,7 @@ export async function adminCreateLocalUser(i: {
   firstName: string,
   lastName?: string,
   email: string,
+  username: string,
 }) {
   return await ds.adminCreateLocalUser(i)
 }


### PR DESCRIPTION
This PR renames userkey to username. It also drops the requirement for email for logging in and instead favors username, which was closer to reality anyway.

Users are semi-forced into using the same username for both local auth and webauthn, but a user can avoid this by deleting their local auth and webauthn, and then re-creating, which gives them access to set their username to whatever they want. Note that username is primarily a backend field, and not really exposed to users so its probably not a huge concern.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.