### PR TITLE
Allow for common recovery link on login page

### DIFF
--- a/frontend/src/authschemes/local/login/index.tsx
+++ b/frontend/src/authschemes/local/login/index.tsx
@@ -1,13 +1,12 @@
-// Copyright 2020, Verizon Media
+// Copyright 2022, Yahoo Inc.
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
 import Form from 'src/components/form'
 import Input from 'src/components/input'
 import Modal from 'src/components/modal'
-import { NavLinkButton } from 'src/components/button'
 import classnames from 'classnames/bind'
-import { login, register, requestRecovery, userResetPassword, totpLogin } from '../services'
+import { login, register, userResetPassword, totpLogin } from '../services'
 import { useForm, useFormField } from 'src/helpers/use_form'
 import { useModal, renderModals, OnRequestClose } from 'src/helpers'
 const cx = classnames.bind(require('./stylesheet'))
@@ -43,8 +42,6 @@ export default (props: {
   switch (props.query.get('step')) {
     case 'reset': return <ResetPassword />
     case 'totp': return <EnterTotp />
-    case 'recovery': return <RecoverUserAccount />
-    case 'recovery-sent': return <AccountRecoveryStarted />
     default: return <Login authFlags={props.authFlags} />
   }
 }
@@ -75,9 +72,6 @@ const Login = (props: {
         <Input label="Username" autoFocus {...usernameField} />
         <Input label="Password" type="password" {...passwordField} />
       </Form>
-      <div className={cx('recover-container')}>
-        <a className={cx('recover-link')} href="/login/local?step=recovery" title="Account Recovery">Forgot your password?</a>
-      </div>
       {renderModals(registerModal)}
     </div>
   )
@@ -172,37 +166,3 @@ const EnterTotp = (props: {}) => {
     </Form>
   </>)
 }
-
-const RecoverUserAccount = (props: {}) => {
-  const emailField = useFormField('')
-
-  const emailForm = useForm({
-    fields: [emailField],
-    handleSubmit: () => {
-      if (emailField.value.trim() == '') {
-        return Promise.reject(Error("Please supply a valid email address"))
-      }
-      return requestRecovery(emailField.value).then(() => window.location.href = '/login/local?step=recovery-sent')
-    }
-  })
-
-  return (<>
-    <h2 className={cx('title')}>Find Your Account</h2>
-    <Form submitText="Submit" {...emailForm}>
-      <Input label="Contact Email" {...emailField} />
-    </Form>
-  </>)
-}
-
-const AccountRecoveryStarted = (props: {
-
-}) => (
-  <div>
-    <div className={cx('messagebox')}>
-      You should receive an email shortly with a recovery link.
-    </div>
-    <NavLinkButton primary className={cx('centered-button')} to={'/login'}>
-      Return to Login
-    </NavLinkButton>
-  </div>
-)

--- a/frontend/src/authschemes/local/login/stylesheet.styl
+++ b/frontend/src/authschemes/local/login/stylesheet.styl
@@ -17,15 +17,6 @@
   text-align: center
   margin-bottom: 20px
 
-.recover-link
-  cursor: pointer
-
-.recover-container
-  text-align: right
-  margin-top: 5px
-  margin-bottom: 5px
-
-
 .centered-button
   position: absolute
   left: 50%

--- a/frontend/src/authschemes/local/services.ts
+++ b/frontend/src/authschemes/local/services.ts
@@ -4,10 +4,6 @@ export async function login(username: string, password: string) {
   await req('POST', '/auth/local/login', { username, password })
 }
 
-export async function requestRecovery(email: string) {
-  await req('POST', '/auth/recovery/generateemail', { userEmail: email })
-}
-
 export async function register(i: {
   firstName: string,
   lastName: string,

--- a/frontend/src/authschemes/recovery/constants.ts
+++ b/frontend/src/authschemes/recovery/constants.ts
@@ -1,0 +1,4 @@
+// Copyright 2022, Yahoo Inc.
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+export const RecoverySchemeName = "recover"

--- a/frontend/src/authschemes/recovery/index.tsx
+++ b/frontend/src/authschemes/recovery/index.tsx
@@ -1,0 +1,70 @@
+// Copyright 2022, Yahoo Inc.
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+import * as React from 'react'
+import classnames from 'classnames/bind'
+
+import { NavLinkButton } from 'src/components/button'
+import Form from 'src/components/form'
+import Input from 'src/components/input'
+import { useForm, useFormField } from 'src/helpers/use_form'
+
+import { requestRecovery } from './services'
+import { RecoverySchemeName } from './constants'
+
+const cx = classnames.bind(require('./stylesheet'))
+
+/**
+ * Note that recovery is a special authentication scheme that cannot be disabled. Originally, it was
+ * part of local auth, but it has been made to work generically. You cannot link recovery, nor are
+ * there other settings. Likewise, you don't really "login" or register, but instead just get
+ * recovery codes. As such, while this is an auth scheme, it is not treated like a normal auth scheme,
+ * and instead just exposes the two components we need to ensure that recovery works, and is possible
+ * for all auth schemes.
+ */
+
+/**
+ * Returns either the initial recovery component, or the recovery-sent page, depending on the url
+ * query string.
+ */
+export default (props: {
+  query: URLSearchParams,
+  authFlags?: Array<string>
+}) => {
+  if (props.query.get('step') === 'recovery-sent') {
+    return <AccountRecoveryStarted />
+  }
+  return <RecoverUserAccount />
+}
+
+const RecoverUserAccount = (_: {}) => {
+  const emailField = useFormField('')
+
+  const emailForm = useForm({
+    fields: [emailField],
+    handleSubmit: () => {
+      if (emailField.value.trim() == '') {
+        return Promise.reject(Error("Please supply a valid email address"))
+      }
+      return requestRecovery(emailField.value).then(() => window.location.href = `/login/${RecoverySchemeName}?step=recovery-sent`)
+    }
+  })
+
+  return (<>
+    <h2 className={cx('title')}>Find Your Account</h2>
+    <Form submitText="Submit" {...emailForm}>
+      <Input label="Contact Email" {...emailField} />
+    </Form>
+  </>)
+}
+
+const AccountRecoveryStarted = (_: {}) => (
+  <div>
+    <div className={cx('messagebox')}>
+      You should receive an email shortly with a recovery link.
+    </div>
+    <NavLinkButton primary className={cx('centered-button')} to={'/login'}>
+      Return to Login
+    </NavLinkButton>
+  </div>
+)

--- a/frontend/src/authschemes/recovery/services.ts
+++ b/frontend/src/authschemes/recovery/services.ts
@@ -1,0 +1,9 @@
+// Copyright 2022, Yahoo Inc.
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+import req from 'src/services/data_sources/backend/request_helper'
+
+
+export async function requestRecovery(email: string) {
+  await req('POST', '/auth/recovery/generateemail', { userEmail: email })
+}

--- a/frontend/src/authschemes/recovery/stylesheet.styl
+++ b/frontend/src/authschemes/recovery/stylesheet.styl
@@ -1,0 +1,25 @@
+@import "~src/vars"
+
+// same as profile's .update-success, modeled after form's .error
+.messagebox
+  margin-bottom: 10px
+  box-sizing: border-box
+  border-radius: 3px
+  font-weight: 800
+  line-height: 25px
+  padding: 5px 5px 5px 10px
+  background: $listen
+  box-shadow: 1px 1px 1px 0 rgba(#000, 0.3)
+
+.title
+  font-weight: plain
+  font-size: 20px
+  text-align: center
+  margin-bottom: 20px
+
+.centered-button
+  position: absolute
+  left: 50%
+  transform: translate(-50%, 0)
+  -ms-transform: translate(-50%, 0);
+

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -5,6 +5,8 @@ import * as React from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import { useAuthFrontendComponent } from 'src/authschemes'
+import Recovery from 'src/authschemes/recovery'
+import { RecoverySchemeName } from 'src/authschemes/recovery/constants'
 import Button from 'src/components/button'
 import { SupportedAuthenticationScheme } from 'src/global_types'
 import { useWiredData } from 'src/helpers'
@@ -41,10 +43,20 @@ export default () => {
 
     return (
       <div className={cx('login')}>
-        {oneScheme
-          ? <AuthSchemeLogin key={oneScheme.schemeCode} authScheme={oneScheme} query={query} />
-          : <LoginMenu authSchemes={supportedAuthSchemes} query={query} />
+        {(renderOnlyScheme === RecoverySchemeName)
+          ? <Recovery query={query} />
+          : (<>
+            {
+              oneScheme
+                ? <AuthSchemeLogin key={oneScheme.schemeCode} authScheme={oneScheme} query={query} />
+                : <LoginMenu authSchemes={supportedAuthSchemes} query={query} />
+            }
+            <div className={cx('recover-container')}>
+              <a className={cx('recover-link')} href="/login/recover" title="Account Recovery">Forgot how to log in?</a>
+            </div>
+          </>)
         }
+
       </div>
     )
   })

--- a/frontend/src/pages/login/stylesheet.styl
+++ b/frontend/src/pages/login/stylesheet.styl
@@ -34,3 +34,11 @@
 
 .full-width-button
   width: 100%
+
+.recover-link
+  cursor: pointer
+
+.recover-container
+  text-align: right
+  margin-top: 5px
+  margin-bottom: 5px


### PR DESCRIPTION
This PR revises the recovery auth scheme to live apart from the local auth login (on the frontend -- recovery auth is already separate, and special, on the backend). Now, under the login options page and specific login pages (e.g. `/login/local`), there is a "Forgot how to log in" link that can be clicked and directed to the recovery flow. The recovery flow itself stays the same.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.