### PR TITLE
Disable non-admin editing

### DIFF
--- a/frontend/src/components/date_range_picker/index.tsx
+++ b/frontend/src/components/date_range_picker/index.tsx
@@ -10,7 +10,7 @@ import { subDays, startOfMonth, endOfMonth } from 'date-fns'
 import Button from 'src/components/button'
 import Popover from 'src/components/popover'
 
-import { 
+import {
   DateRange,
   MaybeDateRange,
   stringifyRange,

--- a/frontend/src/helpers/highlight_substring.tsx
+++ b/frontend/src/helpers/highlight_substring.tsx
@@ -7,11 +7,11 @@ import { escapeRegExp } from 'lodash'
 /**
  * highlightSubstring breaks a given string into words that match the given regex, joined with
  * the rest of the string. This should preserve case.
- * 
+ *
  * Note: this probably isn't close to the speediest solution. Use caution (and minLength option) when
  * using this with a large piece of text.
- * 
- * @example 
+ *
+ * @example
  * const result = highlightSubstring("The quick brown fox jumps over the lazy dog.", /the/gi, "highlight")
  * assert( result, [
  *   <span className="highlight">The</span>,
@@ -19,7 +19,7 @@ import { escapeRegExp } from 'lodash'
  *   <span className="highlight">the</span>,
  *   <span> lazy dog.</span>,
  * ])
- * 
+ *
  * @param s The string with a substring to highlight
  * @param regex What part of the string to match. Must be a global match (/.../g)
  * @param className What class name to apply to the highlighted word

--- a/frontend/src/helpers/use_wired_data.tsx
+++ b/frontend/src/helpers/use_wired_data.tsx
@@ -65,10 +65,12 @@ import { PaginationResult } from 'src/global_types'
 // without sending many intermediate requests
 
 type Renderer<T> = (data: T) => React.ReactElement
+type Exposer<T> = (data: T) => void
 export type WiredData<T> = {
   loading: boolean,
   reload: () => void,
   render: (renderer: Renderer<T>) => React.ReactElement
+  expose: (exposer: Exposer<T>) => void
 }
 
 export type PaginatedWiredData<T> = WiredData<Array<T>> & {
@@ -134,6 +136,10 @@ export function useWiredData<T>(
       if (loading || data == null) return loadingRenderer()
       return renderer(data.value)
     },
+    expose(exposer: Exposer<T>) {
+      if (data == null) return null
+      return exposer(data.value)
+    }
   }
 }
 

--- a/frontend/src/pages/operation_edit/user_permission_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/user_permission_editor/index.tsx
@@ -69,10 +69,10 @@ const NewUserForm = (props: {
 }
 
 const PermissionTableRow = (props: {
+  disabled?: boolean,
   role: UserRole,
   user: User,
   currentUser: UserOwnView | null,
-  isAdmin: boolean,
   requestReload: () => void
   updatePermissions: (role: UserRole) => Promise<void>
 }) => {
@@ -86,7 +86,7 @@ const PermissionTableRow = (props: {
     }} />
   ))
 
-  const disabled = !props.isAdmin || (isCurrentUser && !props.isAdmin)
+  const disabled = props.disabled 
 
   return (
     <>
@@ -166,7 +166,7 @@ const PermissionTable = (props: {
               {renderableData.map(({ user, role }) => (
                 <PermissionTableRow
                   currentUser={currentUser}
-                  isAdmin={isAdmin}
+                  disabled={!isAdmin}
                   key={user.slug}
                   requestReload={props.requestReload}
                   updatePermissions={(r: UserRole) => setUserPermission({ operationSlug: props.operationSlug, userSlug: user.slug, role: r })}

--- a/frontend/src/pages/operation_edit/user_permission_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/user_permission_editor/index.tsx
@@ -169,8 +169,6 @@ const PermissionTable = (props: {
         const matchingUsers = data.filter(({ user }) => normalizeName(user).includes(normalizedSearchTerm))
         const renderableData = matchingUsers.filter((_, i) => i >= ((currentPage - 1) * itemsPerPage) && i < (itemsPerPage * currentPage))
 
-        // const isOperationAdmin = renderableData.find(datum => datum.user.slug === props.currentUser?.slug)?.role === UserRole.ADMIN
-        // props.setIsOperationAdmin(isOperationAdmin)
         const notAdmin = !props.isAdmin && !isOperationAdmin
         
         return (

--- a/frontend/src/pages/operation_show/layout/toolbar/search_modal.tsx
+++ b/frontend/src/pages/operation_show/layout/toolbar/search_modal.tsx
@@ -231,7 +231,7 @@ const HelpText: Array<FilterDetail> = [
         <p>
           Filters the result by requiring that some metadata contains the provided value. Multiple
           values can be specified. When multiples are specified, the metadata must contain <em>all</em>{" "}
-          of the values. 
+          of the values.
         </p>
       </>
   },

--- a/frontend/src/services/data_sources/data_source.ts
+++ b/frontend/src/services/data_sources/data_source.ts
@@ -37,7 +37,7 @@ type ServiceWorkerPayload = {
 
 export interface DataSource {
   flags(): Promise<dtos.Flags>
-  
+
   listApiKeys(ids?: UserSlug): Promise<Array<dtos.APIKey>>
   createApiKey(ids: UserSlug): Promise<dtos.APIKey>
   deleteApiKey(ids: UserSlug & { accessKey: string }): Promise<void>


### PR DESCRIPTION
This PR disables UI that appears to let non-admin users
1.  Edit the permissions of other users (note that these actions are already disallowed on the backend, but the user can't tell that).
2. Add new users to the operation

### Old Version
(note that Ron is an admin in this screenshot, but it would look the same even if he wasn't)
<img width="628" alt="Screen Shot 2022-09-15 at 10 23 51 AM" src="https://user-images.githubusercontent.com/22867407/190429311-325dfec1-e2da-44ec-b933-d44d460e6f63.png">


### New version
<img width="618" alt="Screen Shot 2022-09-15 at 10 11 52 AM" src="https://user-images.githubusercontent.com/22867407/190426434-d00e4dd9-aa49-4dcf-9466-65eb67ab9f30.png">


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.