### PR TITLE
add date created for webauthn keys

### DIFF
--- a/backend/authschemes/webauthn/dtos.go
+++ b/backend/authschemes/webauthn/dtos.go
@@ -3,6 +3,13 @@
 
 package webauthn
 
+import "time"
+
 type ListKeysOutput struct {
-	Keys []string `json:"keys"`
+	Keys []KeyEntry `json:"keys"`
+}
+
+type KeyEntry struct {
+	KeyName     string    `json:"keyName"`
+	DateCreated time.Time `json:"dateCreated"`
 }

--- a/backend/authschemes/webauthn/types.go
+++ b/backend/authschemes/webauthn/types.go
@@ -43,7 +43,7 @@ func unwrapCredential(cred AShirtWebauthnCredential) auth.Credential {
 
 func wrapCredential(cred auth.Credential, extra AShirtWebauthnExtension) AShirtWebauthnCredential {
 	return AShirtWebauthnCredential{
-		Credential: cred,
+		Credential:              cred,
 		AShirtWebauthnExtension: extra,
 	}
 }

--- a/backend/authschemes/webauthn/types.go
+++ b/backend/authschemes/webauthn/types.go
@@ -1,6 +1,8 @@
 package webauthn
 
 import (
+	"time"
+
 	auth "github.com/duo-labs/webauthn/webauthn"
 )
 
@@ -22,20 +24,26 @@ type WebAuthnRegistrationInfo struct {
 	UserID              int64
 	RegistrationType    RegistrationType
 	ExistingCredentials []AShirtWebauthnCredential
+	KeyCreatedDate      time.Time
+}
+
+type AShirtWebauthnExtension struct {
+	KeyName        string    `json:"keyName"`
+	KeyCreatedDate time.Time `json:"keyCreatedDate"`
 }
 
 type AShirtWebauthnCredential struct {
 	auth.Credential
-	KeyName string `json:"keyName"`
+	AShirtWebauthnExtension
 }
 
 func unwrapCredential(cred AShirtWebauthnCredential) auth.Credential {
 	return cred.Credential
 }
 
-func wrapCredential(cred auth.Credential, keyName string) AShirtWebauthnCredential {
+func wrapCredential(cred auth.Credential, extra AShirtWebauthnExtension) AShirtWebauthnCredential {
 	return AShirtWebauthnCredential{
 		Credential: cred,
-		KeyName:    keyName,
+		AShirtWebauthnExtension: extra,
 	}
 }

--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -296,8 +296,11 @@ func (a WebAuthn) getKeys(userID int64, bridge authschemes.AShirtAuthBridge) (*L
 		return nil, backend.WebauthnLoginError(err, "Unable to parse webauthn credentials")
 	}
 
-	results := helpers.Map(creds, func(cred AShirtWebauthnCredential) string {
-		return cred.KeyName
+	results := helpers.Map(creds, func(cred AShirtWebauthnCredential) KeyEntry {
+		return KeyEntry{
+			KeyName:     cred.KeyName,
+			DateCreated: cred.KeyCreatedDate,
+		}
 	})
 	output := ListKeysOutput{results}
 	return &output, nil

--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -414,7 +414,10 @@ func (a WebAuthn) validateRegistrationComplete(r *http.Request, bridge authschem
 		return nil, nil, backend.WrapError("Unable to complete registration", err)
 	}
 
-	data.UserData.Credentials = append(data.UserData.Credentials, wrapCredential(*cred, data.UserData.KeyName))
+	data.UserData.Credentials = append(data.UserData.Credentials, wrapCredential(*cred, AShirtWebauthnExtension{
+		KeyName:        data.UserData.KeyName,
+		KeyCreatedDate: data.UserData.KeyCreatedDate,
+	}))
 
 	encodedCreds, err := json.Marshal(data.UserData.Credentials)
 	if err != nil {

--- a/backend/authschemes/webauthn/webauthnuser.go
+++ b/backend/authschemes/webauthn/webauthnuser.go
@@ -3,6 +3,7 @@ package webauthn
 import (
 	"encoding/binary"
 	"strings"
+	"time"
 
 	auth "github.com/duo-labs/webauthn/webauthn"
 	"github.com/google/uuid"
@@ -10,32 +11,35 @@ import (
 )
 
 type webauthnUser struct {
-	UserID      []byte
-	UserName    string
-	IconURL     string
-	Credentials []AShirtWebauthnCredential
-	FirstName   string
-	LastName    string
-	Email       string
-	KeyName     string
+	UserID         []byte
+	UserName       string
+	IconURL        string
+	Credentials    []AShirtWebauthnCredential
+	FirstName      string
+	LastName       string
+	Email          string
+	KeyName        string
+	KeyCreatedDate time.Time
 }
 
 func makeNewWebAuthnUser(firstName, lastName, email, username, keyName string) webauthnUser {
 	return webauthnUser{
-		UserID:    []byte(uuid.New().String()),
-		UserName:  username,
-		FirstName: firstName,
-		LastName:  lastName,
-		Email:     email,
-		KeyName:   keyName,
+		UserID:         []byte(uuid.New().String()),
+		UserName:       username,
+		FirstName:      firstName,
+		LastName:       lastName,
+		Email:          email,
+		KeyName:        keyName,
+		KeyCreatedDate: time.Now(),
 	}
 }
 
 func makeLinkingWebAuthnUser(userID int64, username, keyName string) webauthnUser {
 	return webauthnUser{
-		UserID:   i64ToByteSlice(userID),
-		UserName: username,
-		KeyName:  keyName,
+		UserID:         i64ToByteSlice(userID),
+		UserName:       username,
+		KeyName:        keyName,
+		KeyCreatedDate: time.Now(),
 	}
 }
 

--- a/frontend/src/authschemes/webauthn/services.ts
+++ b/frontend/src/authschemes/webauthn/services.ts
@@ -5,6 +5,7 @@ import req from 'src/services/data_sources/backend/request_helper'
 
 import {
   CompletedLoginChallenge,
+  KeyEntry,
   KeyList,
   ProvidedCredentialCreationOptions,
   ProvidedCredentialRequestOptions,
@@ -57,7 +58,15 @@ export async function finishAddKey(i: WebAuthNRegisterConfirmation) {
 }
 
 export async function listWebauthnKeys(): Promise<KeyList> {
-  return await req('GET', '/auth/webauthn/keys')
+  const data: KeyList = await req('GET', '/auth/webauthn/keys')
+
+  return {
+    keys: data.keys.map((key: KeyEntry) => ({
+      ...key,
+      dateCreated: new Date(key.dateCreated)
+    }))
+  }
+
 }
 
 export async function deleteWebauthnKey(i: { keyName: string }): Promise<KeyList> {

--- a/frontend/src/authschemes/webauthn/settings/index.tsx
+++ b/frontend/src/authschemes/webauthn/settings/index.tsx
@@ -2,6 +2,8 @@
 // Licensed under the terms of the MIT. See LICENSE file in project root for terms.
 
 import * as React from 'react'
+import * as dateFns from 'date-fns'
+
 import Input from 'src/components/input'
 import SettingsSection from 'src/components/settings_section'
 import classnames from 'classnames/bind'
@@ -15,6 +17,8 @@ import ModalForm from 'src/components/modal_form'
 import { convertToCredentialCreationOptions, encodeAsB64 } from '../helpers'
 import ChallengeModalForm from 'src/components/challenge_modal_form'
 const cx = classnames.bind(require('./stylesheet'))
+
+const toEnUSDate = (d: Date) => dateFns.format(d, "MMM dd, yyyy")
 
 export default (props: {
   username: string,
@@ -46,14 +50,20 @@ const KeyList = (props: {
     {wiredKeys.render(data => {
       return (
         <div>
-          <Table columns={['Key Name', 'Actions']}>
-            {data.keys.map(key => {
+          <Table columns={['Key Name', 'Date Created', 'Actions']}>
+            {data.keys.map(keyEntry => {
+              const { keyName, dateCreated } = keyEntry
               return (
-                <tr key={key}>
-                  <td>{key}</td>
-                  <td><Button small danger onClick={() => {
-                    deleteModal.show({ keyName: key })
-                  }}>Delete</Button></td>
+                <tr key={keyName}>
+                  <td>{keyName}</td>
+                  <td>{toEnUSDate(dateCreated)}</td>
+                  <td>
+                    <Button small danger onClick={() => {
+                      deleteModal.show({ keyName })
+                    }}>
+                      Delete
+                    </Button>
+                  </td>
                 </tr>
               )
             })}

--- a/frontend/src/authschemes/webauthn/types.ts
+++ b/frontend/src/authschemes/webauthn/types.ts
@@ -57,5 +57,10 @@ export type CompletedLoginChallenge = {
 }
 
 export type KeyList = {
-  keys: Array<string>
+  keys: Array<KeyEntry>
+}
+
+export type KeyEntry = {
+  keyName: string
+  dateCreated: Date
 }


### PR DESCRIPTION
This PR adds support for a created date on webauthn keys. it also lists the created date under the user's security tab, along with the name, and the option to delete (Which were pre-existing).

Screenshot of the UI change:

![Screenshot from 2022-09-26 09-13-20](https://user-images.githubusercontent.com/10979605/192327646-182dea01-3743-4ab3-a0cc-d8367295169e.png)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.