### PR TITLE
Move favorites to (new) Operation Preferences

### DIFF
--- a/backend/database/seeding/helpers.go
+++ b/backend/database/seeding/helpers.go
@@ -227,13 +227,21 @@ func newFindingGen(first int64) func(opID int64, uuid string, category *int64, t
 	}
 }
 
-func newUserOpPermission(user models.User, op models.Operation, role policy.OperationRole, favorite ...bool) models.UserOperationPermission {
+func newUserOpPermission(user models.User, op models.Operation, role policy.OperationRole) models.UserOperationPermission {
 	return models.UserOperationPermission{
 		UserID:      user.ID,
 		OperationID: op.ID,
 		Role:        role,
 		CreatedAt:   internalClock.Now(),
-		IsFavorite:  len(favorite) > 0,
+	}
+}
+
+func newUserOperationPreferences(user models.User, op models.Operation, isFavorite bool) models.UserOperationPreferences {
+	return models.UserOperationPreferences{
+		UserID:      user.ID,
+		OperationID: op.ID,
+		IsFavorite:  isFavorite,
+		CreatedAt:   internalClock.Now(),
 	}
 }
 

--- a/backend/database/seeding/hp_seed_data.go
+++ b/backend/database/seeding/hp_seed_data.go
@@ -38,6 +38,14 @@ var HarryPotterSeedData = Seeder{
 		APIKeyRon1, APIKeyRon2,
 		APIKeyNick,
 	},
+	UserOpPrefMap: []models.UserOperationPreferences{
+		newUserOperationPreferences(UserRon, OpChamberOfSecrets, true),
+		newUserOperationPreferences(UserDumbledore, OpGobletOfFire, true),
+		// This user doesn't have permission to view this operation. This helps check that it's okay
+		// to not clean this data up. (and other checks should verify the users don't need to have
+	    // not-a-favorite set up.)
+		newUserOperationPreferences(UserDraco, OpChamberOfSecrets, true),
+	},
 	UserOpMap: []models.UserOperationPermission{
 		// OpSorcerersStone and OpChamberOfSecrets are used to check read/write permissions
 		// The following should always remain true:
@@ -56,7 +64,7 @@ var HarryPotterSeedData = Seeder{
 		newUserOpPermission(UserHermione, OpSorcerersStone, policy.OperationRoleRead),
 		newUserOpPermission(UserNeville, OpSorcerersStone, policy.OperationRoleWrite),
 
-		newUserOpPermission(UserRon, OpChamberOfSecrets, policy.OperationRoleAdmin, true),
+		newUserOpPermission(UserRon, OpChamberOfSecrets, policy.OperationRoleAdmin),
 		newUserOpPermission(UserHarry, OpChamberOfSecrets, policy.OperationRoleWrite),
 		newUserOpPermission(UserHermione, OpChamberOfSecrets, policy.OperationRoleWrite),
 		newUserOpPermission(UserSeamus, OpChamberOfSecrets, policy.OperationRoleRead),
@@ -87,7 +95,7 @@ var HarryPotterSeedData = Seeder{
 
 		newUserOpPermission(UserDumbledore, OpSorcerersStone, policy.OperationRoleAdmin),
 		newUserOpPermission(UserDumbledore, OpChamberOfSecrets, policy.OperationRoleAdmin),
-		newUserOpPermission(UserDumbledore, OpGobletOfFire, policy.OperationRoleAdmin, true),
+		newUserOpPermission(UserDumbledore, OpGobletOfFire, policy.OperationRoleAdmin),
 	},
 	Findings: []models.Finding{
 		FindingBook2Magic, FindingBook2CGI, FindingBook2SpiderFear, FindingBook2Robes,

--- a/backend/database/seeding/hp_seed_data.go
+++ b/backend/database/seeding/hp_seed_data.go
@@ -43,7 +43,7 @@ var HarryPotterSeedData = Seeder{
 		newUserOperationPreferences(UserDumbledore, OpGobletOfFire, true),
 		// This user doesn't have permission to view this operation. This helps check that it's okay
 		// to not clean this data up. (and other checks should verify the users don't need to have
-	    // not-a-favorite set up.)
+		// not-a-favorite set up.)
 		newUserOperationPreferences(UserDraco, OpChamberOfSecrets, true),
 	},
 	UserOpMap: []models.UserOperationPermission{

--- a/backend/database/seeding/seeder.go
+++ b/backend/database/seeding/seeder.go
@@ -30,6 +30,7 @@ type Seeder struct {
 	DefaultTags       []models.DefaultTag
 	Tags              []models.Tag
 	UserOpMap         []models.UserOperationPermission
+	UserOpPrefMap     []models.UserOperationPreferences
 	TagEviMap         []models.TagEvidenceMap
 	EviFindingsMap    []models.EvidenceFindingMap
 	Queries           []models.Query
@@ -124,7 +125,15 @@ func (seed Seeder) ApplyTo(db *database.Connection) error {
 				"role":         seed.UserOpMap[i].Role,
 				"created_at":   seed.UserOpMap[i].CreatedAt,
 				"updated_at":   seed.UserOpMap[i].UpdatedAt,
-				"is_favorite":  seed.UserOpMap[i].IsFavorite,
+			}
+		})
+		tx.BatchInsert("user_operation_preferences", len(seed.UserOpPrefMap), func(i int) map[string]interface{} {
+			return map[string]interface{}{
+				"user_id":      seed.UserOpPrefMap[i].UserID,
+				"operation_id": seed.UserOpPrefMap[i].OperationID,
+				"created_at":   seed.UserOpPrefMap[i].CreatedAt,
+				"updated_at":   seed.UserOpPrefMap[i].UpdatedAt,
+				"is_favorite":  seed.UserOpPrefMap[i].IsFavorite,
 			}
 		})
 		tx.BatchInsert("default_tags", len(seed.DefaultTags), func(i int) map[string]interface{} {

--- a/backend/migrations/20221111221242-create-user-operation-preferences.sql
+++ b/backend/migrations/20221111221242-create-user-operation-preferences.sql
@@ -1,0 +1,39 @@
+-- +migrate Up
+CREATE TABLE `user_operation_preferences` (
+    `user_id` int NOT NULL,
+    `operation_id` int NOT NULL,
+    `is_favorite` boolean NOT NULL DEFAULT false,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP,
+    PRIMARY KEY (`user_id`, `operation_id`),
+    KEY `operation_id` (`operation_id`),
+    CONSTRAINT `user_operation_preferences_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+    CONSTRAINT `user_operation_preferences_ibfk_2` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET = utf8
+;
+
+
+INSERT INTO `user_operation_preferences` (`user_id`, `operation_id`, `is_favorite`)
+    SELECT `user_id`, `operation_id`, `is_favorite` from `user_operation_permissions`
+;
+
+ALTER TABLE
+    `user_operation_permissions` DROP COLUMN `is_favorite`;
+
+-- +migrate Down
+
+ALTER TABLE `user_operation_permissions`
+    ADD COLUMN `is_favorite` BOOLEAN DEFAULT false AFTER role
+;
+
+UPDATE `user_operation_permissions` `perm`
+    INNER JOIN `user_operation_preferences` `pref` ON (
+        `perm`.`user_id` = `pref`.`user_id`
+        AND `perm`.`operation_id` = `pref`.`operation_id`
+    )
+    SET `perm`.`is_favorite` = `pref`.`is_favorite`
+    WHERE true
+;
+
+DROP TABLE `user_operation_preferences`
+;

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -118,10 +118,17 @@ type User struct {
 type UserOperationPermission struct {
 	UserID      int64                `db:"user_id"`
 	OperationID int64                `db:"operation_id"`
-	IsFavorite  bool                 `db:"is_favorite"`
 	Role        policy.OperationRole `db:"role"`
 	CreatedAt   time.Time            `db:"created_at"`
 	UpdatedAt   *time.Time           `db:"updated_at"`
+}
+
+type UserOperationPreferences struct {
+	UserID      int64      `db:"user_id"`
+	OperationID int64      `db:"operation_id"`
+	IsFavorite  bool       `db:"is_favorite"`
+	CreatedAt   time.Time  `db:"created_at"`
+	UpdatedAt   *time.Time `db:"updated_at"`
 }
 
 // Query reflects the structure of the database table 'queries'

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.0.30, for Linux (aarch64)
+-- MySQL dump 10.13  Distrib 8.0.22, for Linux (x86_64)
 --
 -- Host: localhost    Database: migrate_db
 -- ------------------------------------------------------
--- Server version	8.0.30
+-- Server version	8.0.22
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -34,7 +34,7 @@ CREATE TABLE `api_keys` (
   UNIQUE KEY `access_key` (`access_key`),
   KEY `user_id` (`user_id`),
   CONSTRAINT `api_keys_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -61,7 +61,7 @@ CREATE TABLE `auth_scheme_data` (
   UNIQUE KEY `auth_scheme_user_key` (`auth_scheme`,`username`),
   KEY `fk_user_id__users_id` (`user_id`),
   CONSTRAINT `fk_user_id__users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -79,7 +79,7 @@ CREATE TABLE `default_tags` (
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -102,7 +102,7 @@ CREATE TABLE `email_queue` (
   PRIMARY KEY (`id`),
   KEY `email_queue__email_status` (`email_status`),
   KEY `email_queue__email_to` (`to_email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -130,7 +130,7 @@ CREATE TABLE `evidence` (
   KEY `operator_id` (`operator_id`),
   CONSTRAINT `evidence_ibfk_1` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`),
   CONSTRAINT `evidence_ibfk_2` FOREIGN KEY (`operator_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -149,7 +149,7 @@ CREATE TABLE `evidence_finding_map` (
   KEY `event_id` (`finding_id`),
   CONSTRAINT `evidence_finding_map_ibfk_1` FOREIGN KEY (`evidence_id`) REFERENCES `evidence` (`id`) ON DELETE CASCADE,
   CONSTRAINT `evidence_finding_map_ibfk_2` FOREIGN KEY (`finding_id`) REFERENCES `findings` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -174,7 +174,7 @@ CREATE TABLE `evidence_metadata` (
   UNIQUE KEY `evidence_id` (`evidence_id`,`source`),
   KEY `evidence_id_2` (`evidence_id`),
   CONSTRAINT `evidence_metadata_ibfk_1` FOREIGN KEY (`evidence_id`) REFERENCES `evidence` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -192,7 +192,7 @@ CREATE TABLE `finding_categories` (
   `deleted_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `category` (`category`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -219,7 +219,7 @@ CREATE TABLE `findings` (
   KEY `fk_category_id__finding_categories_id` (`category_id`),
   CONSTRAINT `findings_ibfk_1` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`),
   CONSTRAINT `fk_category_id__finding_categories_id` FOREIGN KEY (`category_id`) REFERENCES `finding_categories` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -233,7 +233,7 @@ CREATE TABLE `gorp_migrations` (
   `id` varchar(255) NOT NULL,
   `applied_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -253,7 +253,7 @@ CREATE TABLE `operations` (
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `slug` (`slug`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -275,7 +275,7 @@ CREATE TABLE `queries` (
   UNIQUE KEY `name` (`name`,`operation_id`,`type`),
   UNIQUE KEY `query` (`query`,`operation_id`,`type`),
   KEY `operation_id` (`operation_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -294,7 +294,7 @@ CREATE TABLE `service_workers` (
   `deleted_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -333,7 +333,7 @@ CREATE TABLE `tag_evidence_map` (
   KEY `evidence_id` (`evidence_id`),
   CONSTRAINT `tag_evidence_map_ibfk_1` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`),
   CONSTRAINT `tag_evidence_map_ibfk_2` FOREIGN KEY (`evidence_id`) REFERENCES `evidence` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -353,7 +353,7 @@ CREATE TABLE `tags` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`,`operation_id`),
   KEY `operation_id` (`operation_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -367,14 +367,33 @@ CREATE TABLE `user_operation_permissions` (
   `user_id` int NOT NULL,
   `operation_id` int NOT NULL,
   `role` varchar(255) NOT NULL,
-  `is_favorite` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`user_id`,`operation_id`),
   KEY `operation_id` (`operation_id`),
   CONSTRAINT `user_operation_permissions_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `user_operation_permissions_ibfk_2` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `user_operation_preferences`
+--
+
+DROP TABLE IF EXISTS `user_operation_preferences`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `user_operation_preferences` (
+  `user_id` int NOT NULL,
+  `operation_id` int NOT NULL,
+  `is_favorite` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`operation_id`),
+  KEY `operation_id` (`operation_id`),
+  CONSTRAINT `user_operation_preferences_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `user_operation_preferences_ibfk_2` FOREIGN KEY (`operation_id`) REFERENCES `operations` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -399,7 +418,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `slug` (`slug`),
   UNIQUE KEY `unique_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -411,12 +430,12 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-10-27 15:39:55
--- MySQL dump 10.13  Distrib 8.0.30, for Linux (aarch64)
+-- Dump completed on 2022-11-11 22:48:03
+-- MySQL dump 10.13  Distrib 8.0.22, for Linux (x86_64)
 --
 -- Host: localhost    Database: migrate_db
 -- ------------------------------------------------------
--- Server version	8.0.30
+-- Server version	8.0.22
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -435,7 +454,7 @@ CREATE TABLE `users` (
 
 LOCK TABLES `gorp_migrations` WRITE;
 /*!40000 ALTER TABLE `gorp_migrations` DISABLE KEYS */;
-INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2022-10-27 15:39:54'),('20190708185420-create-operations-table.sql','2022-10-27 15:39:54'),('20190708185427-create-events-table.sql','2022-10-27 15:39:54'),('20190708185432-create-evidence-table.sql','2022-10-27 15:39:54'),('20190708185441-create-evidence-event-map-table.sql','2022-10-27 15:39:54'),('20190716190100-create-user-operation-map-table.sql','2022-10-27 15:39:54'),('20190722193434-create-tags-table.sql','2022-10-27 15:39:54'),('20190722193937-create-tag-event-map.sql','2022-10-27 15:39:54'),('20190909183500-add-short-name-to-users-table.sql','2022-10-27 15:39:54'),('20190909190416-add-short-name-index.sql','2022-10-27 15:39:54'),('20190926205116-evidence-name.sql','2022-10-27 15:39:54'),('20190930173342-add-saved-searches.sql','2022-10-27 15:39:54'),('20191001182541-evidence-tags.sql','2022-10-27 15:39:54'),('20191008005212-add-uuid-to-events-evidence.sql','2022-10-27 15:39:54'),('20191015235306-add-slug-to-operations.sql','2022-10-27 15:39:54'),('20191018172105-modular-auth.sql','2022-10-27 15:39:54'),('20191023170906-codeblock.sql','2022-10-27 15:39:54'),('20191101185207-replace-events-with-findings.sql','2022-10-27 15:39:54'),('20191114211948-add-operation-to-tags.sql','2022-10-27 15:39:54'),('20191205182830-create-api-keys-table.sql','2022-10-27 15:39:54'),('20191213222629-users-with-email.sql','2022-10-27 15:39:54'),('20200103194053-rename-short-name-to-slug.sql','2022-10-27 15:39:55'),('20200104013804-rework-ashirt-auth.sql','2022-10-27 15:39:55'),('20200116070736-add-admin-flag.sql','2022-10-27 15:39:55'),('20200130175541-fix-color-truncation.sql','2022-10-27 15:39:55'),('20200205200208-disable-user-support.sql','2022-10-27 15:39:55'),('20200215015330-optional-user-id.sql','2022-10-27 15:39:55'),('20200221195107-deletable-user.sql','2022-10-27 15:39:55'),('20200303215004-move-last-login.sql','2022-10-27 15:39:55'),('20200306221628-add-explicit-headless.sql','2022-10-27 15:39:55'),('20200331155258-finding-status.sql','2022-10-27 15:39:55'),('20200617193248-case-senitive-apikey.sql','2022-10-27 15:39:55'),('20200928160958-add-totp-secret-to-auth-table.sql','2022-10-27 15:39:55'),('20210120205510-create-email-queue-table.sql','2022-10-27 15:39:55'),('20210401220807-dynamic-categories.sql','2022-10-27 15:39:55'),('20210408212206-remove-findings-category.sql','2022-10-27 15:39:55'),('20210730170543-add-auth-type.sql','2022-10-27 15:39:55'),('20220211181557-add-default-tags.sql','2022-10-27 15:39:55'),('20220512174013-evidence-metadata.sql','2022-10-27 15:39:55'),('20220516163424-add-worker-services.sql','2022-10-27 15:39:55'),('20220811153414-webauthn-credentials.sql','2022-10-27 15:39:55'),('20220908193523-switch-to-username.sql','2022-10-27 15:39:55'),('20220912185024-add-is_favorite.sql','2022-10-27 15:39:55'),('20220916190855-remove-null-as-value-for-is_favorite.sql','2022-10-27 15:39:55'),('20221027152757-remove-operation-status.sql','2022-10-27 15:39:55');
+INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2022-11-11 22:47:58'),('20190708185420-create-operations-table.sql','2022-11-11 22:47:58'),('20190708185427-create-events-table.sql','2022-11-11 22:47:58'),('20190708185432-create-evidence-table.sql','2022-11-11 22:47:58'),('20190708185441-create-evidence-event-map-table.sql','2022-11-11 22:47:59'),('20190716190100-create-user-operation-map-table.sql','2022-11-11 22:47:59'),('20190722193434-create-tags-table.sql','2022-11-11 22:47:59'),('20190722193937-create-tag-event-map.sql','2022-11-11 22:47:59'),('20190909183500-add-short-name-to-users-table.sql','2022-11-11 22:47:59'),('20190909190416-add-short-name-index.sql','2022-11-11 22:47:59'),('20190926205116-evidence-name.sql','2022-11-11 22:47:59'),('20190930173342-add-saved-searches.sql','2022-11-11 22:47:59'),('20191001182541-evidence-tags.sql','2022-11-11 22:47:59'),('20191008005212-add-uuid-to-events-evidence.sql','2022-11-11 22:48:00'),('20191015235306-add-slug-to-operations.sql','2022-11-11 22:48:00'),('20191018172105-modular-auth.sql','2022-11-11 22:48:00'),('20191023170906-codeblock.sql','2022-11-11 22:48:00'),('20191101185207-replace-events-with-findings.sql','2022-11-11 22:48:00'),('20191114211948-add-operation-to-tags.sql','2022-11-11 22:48:00'),('20191205182830-create-api-keys-table.sql','2022-11-11 22:48:00'),('20191213222629-users-with-email.sql','2022-11-11 22:48:01'),('20200103194053-rename-short-name-to-slug.sql','2022-11-11 22:48:01'),('20200104013804-rework-ashirt-auth.sql','2022-11-11 22:48:01'),('20200116070736-add-admin-flag.sql','2022-11-11 22:48:01'),('20200130175541-fix-color-truncation.sql','2022-11-11 22:48:01'),('20200205200208-disable-user-support.sql','2022-11-11 22:48:01'),('20200215015330-optional-user-id.sql','2022-11-11 22:48:01'),('20200221195107-deletable-user.sql','2022-11-11 22:48:01'),('20200303215004-move-last-login.sql','2022-11-11 22:48:01'),('20200306221628-add-explicit-headless.sql','2022-11-11 22:48:02'),('20200331155258-finding-status.sql','2022-11-11 22:48:02'),('20200617193248-case-senitive-apikey.sql','2022-11-11 22:48:02'),('20200928160958-add-totp-secret-to-auth-table.sql','2022-11-11 22:48:02'),('20210120205510-create-email-queue-table.sql','2022-11-11 22:48:02'),('20210401220807-dynamic-categories.sql','2022-11-11 22:48:02'),('20210408212206-remove-findings-category.sql','2022-11-11 22:48:02'),('20210730170543-add-auth-type.sql','2022-11-11 22:48:02'),('20220211181557-add-default-tags.sql','2022-11-11 22:48:02'),('20220512174013-evidence-metadata.sql','2022-11-11 22:48:02'),('20220516163424-add-worker-services.sql','2022-11-11 22:48:03'),('20220811153414-webauthn-credentials.sql','2022-11-11 22:48:03'),('20220908193523-switch-to-username.sql','2022-11-11 22:48:03'),('20220912185024-add-is_favorite.sql','2022-11-11 22:48:03'),('20220916190855-remove-null-as-value-for-is_favorite.sql','2022-11-11 22:48:03'),('20221027152757-remove-operation-status.sql','2022-11-11 22:48:03'),('20221111221242-create-user-operation-preferences.sql','2022-11-11 22:48:03');
 /*!40000 ALTER TABLE `gorp_migrations` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -448,4 +467,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-10-27 15:39:55
+-- Dump completed on 2022-11-11 22:48:03

--- a/backend/services/operations.go
+++ b/backend/services/operations.go
@@ -423,9 +423,9 @@ func SetFavoriteOperation(ctx context.Context, db *database.Connection, i SetFav
 	}
 
 	_, err = db.Insert("user_operation_preferences", map[string]interface{}{
-		"user_id": middleware.UserID(ctx),
+		"user_id":      middleware.UserID(ctx),
 		"operation_id": operation.ID,
-		"is_favorite": i.IsFavorite,
+		"is_favorite":  i.IsFavorite,
 	}, "ON DUPLICATE KEY UPDATE is_favorite=VALUES(is_favorite)")
 
 	if err != nil {

--- a/backend/services/operations_test.go
+++ b/backend/services/operations_test.go
@@ -127,14 +127,14 @@ func TestListOperations(t *testing.T) {
 		require.Equal(t, len(expectedOps), len(ops))
 		validateOperationList(ops, expectedOps)
 
-		opsAndPermissions := getFavoritesByUserID(t, db, normalUser.ID)
-		for _, opAndPerm := range opsAndPermissions {
+		opsAndPrefs := getFavoritesByUserID(t, db, normalUser.ID)
+		for _, opPrefs := range opsAndPrefs {
 			_, found := helpers.Find(ops, func(expectedOp *dtos.Operation) bool {
-				return (*expectedOp).Slug == opAndPerm.Slug
+				return (*expectedOp).Slug == opPrefs.Slug
 			})
 			require.NotNil(t, found)
 			fav := (**found).Favorite
-			require.Equal(t, fav, opAndPerm.IsFavorite)
+			require.Equal(t, fav, opPrefs.IsFavorite)
 		}
 
 		// validate headless users
@@ -181,7 +181,7 @@ func TestListOperationsForAdmin(t *testing.T) {
 func TestSetFavoriteOperation(t *testing.T) {
 	RunResettableDBTest(t, func(db *database.Connection, _ TestSeedData) {
 		normalUser := UserRon
-		slug := "HPGoF"
+		slug := OpGobletOfFire.Slug
 
 		isFavorite := getFavoriteForOperation(t, db, slug, normalUser.ID)
 		require.Equal(t, isFavorite, false)


### PR DESCRIPTION
This PR revises how favorites are handled to allow for group access/rbac to work without having to consider a user's individual favorite preferences. This also allows for more operation-based preferences to be added in the future for individual users.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.