### PR TITLE
parse store config for api

### DIFF
--- a/backend/config/webconfig.go
+++ b/backend/config/webconfig.go
@@ -78,6 +78,7 @@ func LoadAPIConfig() error {
 	return loadConfig([]func() error{
 		loadAppConfig,
 		loadDBConfig,
+		loadStoreConfig,
 	})
 }
 


### PR DESCRIPTION
This PR fixes an issue where the store config was never parsed in production-like environments (i.e. not using dev.go).

Note: I was unable to test this due to some time constraints, but it should be pretty obvious if it works. Currently, a non-patched version should render out the message `No content store provided` during startup (regardless of whether a store config is provided), but then fall back to the s3 store. The patched version _should_ now read the store config and shouldn't render this message _unless_ no store config was provided. If no one else can test, I might be able to get to it sometime this weekend or early next week.

Thanks @cyberbulter for finding the issue.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.