### PR TITLE
use mux instead of nil

### DIFF
--- a/backend/bin/api/api.go
+++ b/backend/bin/api/api.go
@@ -41,11 +41,13 @@ func main() {
 		logging.Fatal(logger, "msg", "store setup error", "error", err)
 	}
 
-	http.Handle("/api/", server.API(
+	mux := http.NewServeMux()
+
+	mux.Handle("/api/", server.API(
 		db, contentStore, logger,
 	))
 
 	logger.Log("msg", "starting API server", "port", config.Port())
-	serveErr := http.ListenAndServe(":"+config.Port(), nil)
+	serveErr := http.ListenAndServe(":"+config.Port(), mux)
 	logging.Fatal(logger, "msg", "server shutting down", "err", serveErr)
 }

--- a/backend/bin/dev/dev.go
+++ b/backend/bin/dev/dev.go
@@ -117,7 +117,9 @@ func tryRunServer(logger logging.Logger) error {
 		logger.Log("msg", "No Emailer selected")
 	}
 
-	http.Handle("/web/", http.StripPrefix("/web", server.Web(
+	mux := http.NewServeMux()
+
+	mux.Handle("/web/", http.StripPrefix("/web", server.Web(
 		db, contentStore, &server.WebConfig{
 			CSRFAuthKey:      []byte("DEVELOPMENT_CSRF_AUTH_KEY_SECRET"),
 			SessionStoreKey:  []byte("DEVELOPMENT_SESSION_STORE_KEY_SECRET"),
@@ -126,12 +128,11 @@ func tryRunServer(logger logging.Logger) error {
 			Logger:           logger,
 		},
 	)))
-	http.Handle("/api/", server.API(
+	mux.Handle("/api/", server.API(
 		db, contentStore, logger,
 	))
-
 	logger.Log("port", config.Port(), "msg", "Now Serving")
-	return http.ListenAndServe(":"+config.Port(), nil)
+	return http.ListenAndServe(":"+config.Port(), mux)
 }
 
 func handleAuthType(cfg config.AuthInstanceConfig) (authschemes.AuthScheme, error) {

--- a/backend/bin/web/web.go
+++ b/backend/bin/web/web.go
@@ -86,7 +86,9 @@ func main() {
 		logger.Log("msg", "No Emailer selected")
 	}
 
-	http.Handle("/web/", http.StripPrefix("/web", server.Web(
+	mux := http.NewServeMux()
+
+	mux.Handle("/web/", http.StripPrefix("/web", server.Web(
 		db, contentStore, &server.WebConfig{
 			CSRFAuthKey:      []byte(config.CSRFAuthKey()),
 			SessionStoreKey:  []byte(config.SessionStoreKey()),
@@ -97,7 +99,7 @@ func main() {
 	)))
 
 	logger.Log("msg", "starting Web server", "port", config.Port())
-	serveErr := http.ListenAndServe(":"+config.Port(), nil)
+	serveErr := http.ListenAndServe(":"+config.Port(), mux)
 	logging.Fatal(logger, "msg", "server shutting down", "err", serveErr)
 }
 


### PR DESCRIPTION
passing `nil` as the second arg causes the net/http package to use DefaultServeMux, which uses `expvars`, which creates the `debug/vars` endpoint. This removes access to the debug/vars endpoint on both the dev and prod instances (when running via the appropriate dockerfile) and no functionality seems broken AFAIK (web works fine and tests pass (so I'm assuming the API is working)). Hopefully it works when deployed!

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.