### PR TITLE
supply authnID when linking

### DIFF
--- a/backend/authschemes/webauthn/webauthnuser.go
+++ b/backend/authschemes/webauthn/webauthnuser.go
@@ -38,6 +38,7 @@ func makeNewWebAuthnUser(firstName, lastName, email, username, keyName string) w
 func makeLinkingWebAuthnUser(userID int64, username, keyName string) webauthnUser {
 	return webauthnUser{
 		UserID:         i64ToByteSlice(userID),
+		AuthnID:        []byte(uuid.New().String()),
 		UserName:       username,
 		KeyName:        keyName,
 		KeyCreatedDate: time.Now(),


### PR DESCRIPTION
This PR should restore the ability for users to link their account with a webauthn device. 

should fix issue #825 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.