### PR TITLE
validate resident key with proper config value

### DIFF
--- a/backend/config/authconfig.go
+++ b/backend/config/authconfig.go
@@ -83,7 +83,7 @@ func (w WebauthnConfig) AuthenticatorAttachmentPreference() protocol.Authenticat
 }
 
 func (w WebauthnConfig) AuthenticatorResidentKeyPreference() protocol.ResidentKeyRequirement {
-	val := strings.TrimSpace(strings.ToLower(w.AttestationPreference))
+	val := strings.TrimSpace(strings.ToLower(w.AuthenticatorResidentKey))
 	if val == "preferred" {
 		return protocol.ResidentKeyRequirementPreferred
 	}


### PR DESCRIPTION
This PR attempts to fix the resident key configuration for webauthn. Previously, this field was validated based on a different configuration value, which obviously is incorrect. This should be fixed in this PR.

Note: Only the configuration is fixed. Additional testing will be needed to make sure it actually does the right thing. However, this is ultimately passed to the underlying webauthn go library, so this is likely to induce the correct behavior. (I might have time to test this later)

Possibly address issue #826 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.