### PR TITLE
add export var to readme

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -155,6 +155,8 @@ Configuration is handled entirely via environment variables. To that end, here a
   * `EMAIL_SMTP_AUTH_TYPE`
     * Indicates which kind of authentication scheme to use when connecting to an SMTP server
     * Valid values: `login`, `plain`, `crammd5` (for LOGIN, PLAIN, and CRAM-MD5 respectively)
+  * `ENABLE_EVIDENCE_EXPORT`
+    * When set to `'true'`, used to allow global admins, operation admins, or member of a group with admin permissions to export zipped evidence from an operation
 
 #### Flags
 


### PR DESCRIPTION
Adds the export evidence env var to the readme (didn't think to include it in [831](https://github.com/theparanoids/ashirt-server/pull/831))
 
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.