### PR TITLE
fix webauthn not working as second login

### DIFF
--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -215,8 +215,13 @@ func (a WebAuthn) BindRoutes(r *mux.Router, bridge authschemes.AShirtAuthBridge)
 		if err != nil {
 			return nil, backend.WrapError("Unable to validate registration data", err)
 		}
+
+		rawSessionData := bridge.ReadAuthSchemeSession(r)
+		sessionData, _ := rawSessionData.(*webAuthNSessionData)
+
 		return nil, bridge.CreateNewAuthForUser(authschemes.UserAuthData{
 			UserID:   byteSliceToI64(data.UserData.UserID),
+			AuthnID:  sessionData.UserData.AuthnID,
 			Username: data.UserData.UserName,
 			JSONData: helpers.Ptr(string(encodedCreds)),
 		})


### PR DESCRIPTION
When linking a webauthn account to an account created with the ashirt login, a user was unable to login using the webauthn account; this PR fixes that

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.