### PR TITLE
fix key name and username swap

### DIFF
--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -388,7 +388,7 @@ func (a WebAuthn) beginRegistration(w http.ResponseWriter, r *http.Request, brid
 	} else if info.RegistrationType == LinkCredential {
 		user = makeLinkingWebAuthnUser(info.UserID, info.Username, info.CredentialName)
 	} else { // Add Credential
-		user = makeAddCredentialWebAuthnUser(info.UserID, info.CredentialName, info.Username, info.ExistingCredentials)
+		user = makeAddCredentialWebAuthnUser(info.UserID, info.Username, info.CredentialName, info.ExistingCredentials)
 	}
 
 	credExcludeList := make([]protocol.CredentialDescriptor, len(user.Credentials))


### PR DESCRIPTION
Fix a bug where, when adding a second credential, the credential name was replaced by the username

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.