### PR TITLE
build(deps): align react-dom version with react

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^19.2.6",
         "react-ace": "^14.0.1",
         "react-day-picker": "^9.11.0",
-        "react-dom": "^19.2.4",
+        "react-dom": "^19.2.6",
         "react-dropzone": "^15.0.0",
         "react-markdown": "^10.1.0",
         "react-router": "7.15.1"
@@ -9284,15 +9284,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-dropzone": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "react": "^19.2.6",
     "react-ace": "^14.0.1",
     "react-day-picker": "^9.11.0",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.6",
     "react-dropzone": "^15.0.0",
     "react-markdown": "^10.1.0",
     "react-router": "7.15.1"


### PR DESCRIPTION
## Summary
`react-dom` was pinned to `^19.2.4` while `react` was `^19.2.6`. React and react-dom are published in lockstep and must carry identical versions, so this bumps `react-dom` (and its `package-lock.json` entry) to `^19.2.6`.

## Verification
- `docker compose build` succeeds — both `react-frontend` and `react-backend` images build cleanly.
- `npm ci` passes (strict lockfile/package.json consistency check).
- Resolved tree: `react@19.2.6` and `react-dom@19.2.6`, single deduped copy of each; all peer dependencies (`@testing-library/react`, `react-ace`, `react-router`) satisfied.
- No other packages require updating.